### PR TITLE
Include insertions in data warmup toast

### DIFF
--- a/src/entrypoints/content/in-page-app/toasts.tsx
+++ b/src/entrypoints/content/in-page-app/toasts.tsx
@@ -20,12 +20,18 @@ import { ToastWithTriggeredNotification } from "./toasts/toast-with-triggered-no
 import { ToastWithWelcomeMessage } from "./toasts/toast-with-welcome-message";
 
 export async function checkIfDataWarmupToastNeeded(): Promise<boolean> {
-  const [accountsMetadata, tagsMetadata] = await Promise.all([
-    staticListsService.getListMetadata("accounts"),
-    staticListsService.getListMetadata("tags"),
-  ]);
+  const [accountsMetadata, insertionsMetadata, tagsMetadata] =
+    await Promise.all([
+      staticListsService.getListMetadata("accounts"),
+      staticListsService.getListMetadata("insertions"),
+      staticListsService.getListMetadata("tags"),
+    ]);
 
-  return !accountsMetadata.remoteActive || !tagsMetadata.remoteActive;
+  return (
+    !accountsMetadata.remoteActive ||
+    !insertionsMetadata.remoteActive ||
+    !tagsMetadata.remoteActive
+  );
 }
 
 const useTriggeredNotification = createPollableValueHook(

--- a/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
+++ b/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
@@ -19,10 +19,14 @@ function extractItemCountFromRawSummary(
 }
 
 export function ToastWithDataWarmup({ onClose }: { onClose: () => void }) {
-  const tagsMetadata = useStaticListMetadata("tags");
   const accountsMetadata = useStaticListMetadata("accounts");
+  const insertionsMetadata = useStaticListMetadata("insertions");
+  const tagsMetadata = useStaticListMetadata("tags");
 
-  const done = accountsMetadata.remoteActive && tagsMetadata.remoteActive;
+  const done =
+    accountsMetadata.remoteActive &&
+    insertionsMetadata.remoteActive &&
+    tagsMetadata.remoteActive;
 
   React.useEffect(() => {
     if (done) {
@@ -32,10 +36,12 @@ export function ToastWithDataWarmup({ onClose }: { onClose: () => void }) {
 
   const nextExpectedItemCount =
     (accountsMetadata.remoteNext?.upstreamInfo.itemCount ?? 0) +
+    (insertionsMetadata.remoteNext?.upstreamInfo.itemCount ?? 0) +
     (tagsMetadata.remoteNext?.upstreamInfo.itemCount ?? 0);
 
   const nextItemCount =
     extractItemCountFromRawSummary(accountsMetadata.remoteNext?.summary) +
+    extractItemCountFromRawSummary(insertionsMetadata.remoteNext?.summary) +
     extractItemCountFromRawSummary(tagsMetadata.remoteNext?.summary);
 
   const progressInPercentage = nextExpectedItemCount

--- a/src/entrypoints/popup/app/header.tsx
+++ b/src/entrypoints/popup/app/header.tsx
@@ -66,10 +66,10 @@ function AccountListMetadata() {
 
 export function Header() {
   useStaticListsAutoUpdate({
-    listIds: ["accounts", "tags"],
-    // When a user triggers the popup, we can tolerate accounts and tags being outdated
-    // for one day. This can save some CPU and network traffic. The delay is not set
-    // in content script where we want to mark bots based on fresh data.
+    listIds: ["accounts", "insertions", "tags"],
+    // When a user triggers the popup, we can tolerate accounts, insertions and tags
+    // being outdated for one day. This can save some CPU and network traffic. The delay
+    // is not set in content script where we want to mark bots based on fresh data.
     toleranceInMinutes: 60 * 24,
   });
 


### PR DESCRIPTION
Тост прогрева данных включал аккаунты и теги. Теперь ещё включает вставки, потому что без их полной загрузки подсветка ботов не работает.

Заодно добавил отложенное обновление вставок внутри попапа (так уже делаем для аккаунтов и тегов).