### PR TITLE
Migrate user data from v1 to v2

### DIFF
--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -30,6 +30,7 @@ import { DxConfigService } from "./background/@services/dx-config-service";
 import { ExtensionVersionService } from "./background/@services/extension-version-service";
 import { FrontendService } from "./background/@services/frontend-service";
 import { InspectorService } from "./background/@services/inspector-service";
+import { cleanupLegacyV1State } from "./background/@services/legacy-v1-migration-helpers";
 import { NotificationService } from "./background/@services/notification-service";
 import { PopupService } from "./background/@services/popup-service";
 import { RegDateService } from "./background/@services/reg-date-service";
@@ -199,6 +200,15 @@ export default defineBackground(() => {
   registerService(rootConfigServiceKey, rootConfigService);
   registerService(staticListsServiceKey, staticListsService);
   registerService(userConfigServiceKey, userConfigService);
+
+  // TODO: Remove this legacy cleanup task after the v1 -> v2 upgrade window closes.
+  void Promise.all([
+    authService.waitUntilAuthInputReady(),
+    userConfigService.get(),
+    notificationService.getGlobalNotificationsState(),
+  ]).then(async () => {
+    await cleanupLegacyV1State();
+  });
 
   void orchestrateAliasManagers({
     aliasManagerForDynamicApi,

--- a/src/entrypoints/background/@service-helpers/store-with-schema.ts
+++ b/src/entrypoints/background/@service-helpers/store-with-schema.ts
@@ -23,14 +23,20 @@ export type StoreWithSchema<T extends z.ZodMiniType<JsonValue | undefined>> = {
   watch: (callback: (value: z.infer<T>) => void) => () => void;
 };
 
+type DefineStoreWithSchemaOptions<T extends z.ZodMiniType<JsonValue>> = {
+  migrateDataFromV1?: () => Promise<z.infer<T> | undefined>;
+};
+
 export function defineStoreWithSchema<T extends z.ZodMiniType<JsonValue>>(
   name: StorageItemKey,
   schema: T,
+  options?: DefineStoreWithSchemaOptions<T>,
 ): StoreWithSchema<T> {
   const patchedName = patchNameIfNeeded(name);
   const storageItem = storage.defineItem<JsonValue | undefined>(patchedName);
 
   const logger = getBackgroundLogger(["store", patchedName]);
+  let migrationAttemptPromise: Promise<z.infer<T> | undefined> | undefined;
 
   function parseValue(value: unknown): z.infer<T> {
     const result = schema.safeParse(value);
@@ -48,11 +54,51 @@ export function defineStoreWithSchema<T extends z.ZodMiniType<JsonValue>>(
     return result.data;
   }
 
+  async function migrateValueFromV1(): Promise<z.infer<T> | undefined> {
+    const migrateDataFromV1 = options?.migrateDataFromV1;
+    if (!migrateDataFromV1) {
+      return;
+    }
+
+    migrationAttemptPromise ??= (async () => {
+      try {
+        const migratedValue = await migrateDataFromV1();
+        if (migratedValue === undefined) {
+          return;
+        }
+
+        const migratedValueResult = schema.safeParse(migratedValue);
+        if (!migratedValueResult.success) {
+          logger.error("Invalid migrated value {value}: {error}", {
+            value: migratedValue,
+            error: migratedValueResult.error.message,
+          });
+          return;
+        }
+
+        const parsedMigratedValue = migratedValueResult.data;
+        await storageItem.setValue(parsedMigratedValue);
+        return parsedMigratedValue;
+      } catch (error) {
+        logger.error("Failed to migrate value from v1: {error}", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return;
+      }
+    })();
+
+    return migrationAttemptPromise;
+  }
+
   return {
-    getValue: () =>
-      storageItem
-        .getValue()
-        .then((value) => (value === null ? undefined : parseValue(value))),
+    getValue: async () => {
+      const rawValue = await storageItem.getValue();
+      if (rawValue !== null) {
+        return parseValue(rawValue);
+      }
+
+      return await migrateValueFromV1();
+    },
 
     setValue: (value) => storageItem.setValue(value),
 

--- a/src/entrypoints/background/@services/auth-service.ts
+++ b/src/entrypoints/background/@services/auth-service.ts
@@ -30,12 +30,15 @@ import {
   OrpcErrorRemoteSystemUnavailable,
 } from "../@service-helpers/orpc";
 import { defineStoreWithSchema } from "../@service-helpers/store-with-schema";
+import { migrateAuthInputFromV1 } from "./legacy-v1-migration-helpers";
 
 const logger = getBackgroundLogger(["auth-service"]);
 
+// TODO: Remove `migrateDataFromV1` after the v1 -> v2 upgrade window closes.
 const authInputStore = defineStoreWithSchema(
   "sync:auth-input",
   authInputSchema,
+  { migrateDataFromV1: migrateAuthInputFromV1 },
 );
 
 const defaultAuthInput: AuthInput = {
@@ -99,9 +102,14 @@ export class AuthService {
     return result;
   }
 
-  async getAuthInput(): Promise<AuthInput> {
+  private async getAuthInput(): Promise<AuthInput> {
     const result = await this.pollAuthInput(undefined);
     return result.value;
+  }
+
+  // TODO: Remove this method after the v1 -> v2 upgrade window closes.
+  async waitUntilAuthInputReady(): Promise<void> {
+    await this.pollAuthInput(undefined);
   }
 
   pollAuthStatus(

--- a/src/entrypoints/background/@services/legacy-v1-migration-helpers.test.ts
+++ b/src/entrypoints/background/@services/legacy-v1-migration-helpers.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import type { AuthInput } from "@/shared/@model/auth";
+import { defaultUserConfig } from "@/shared/@model/user-config";
+import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
+
+import {
+  createGlobalNotificationsStateForLegacyV1User,
+  hasLegacyV1FootprintInLocalStorage,
+  migrateAuthInputFromLegacyTokenState,
+  migrateUserConfigFromLegacyState,
+} from "./legacy-v1-migration-helpers";
+
+function authInput(accessCode: string): AuthInput {
+  return {
+    accessCode,
+    accessCodeEnteredAt: isoDateTimeSchema.parse("2024-01-01T00:00:00Z"),
+  };
+}
+
+describe("migrateAuthInputFromLegacyTokenState", () => {
+  it("should migrate legacy access code into v2 auth input", () => {
+    const result = migrateAuthInputFromLegacyTokenState({
+      legacyTokenState: {
+        userToken: "  legacy-access-code  ",
+      },
+      migratedAt: isoDateTimeSchema.parse("2024-02-01T00:00:00Z"),
+    });
+
+    expect(result).toEqual({
+      accessCode: "legacy-access-code",
+      accessCodeEnteredAt: isoDateTimeSchema.parse("2024-02-01T00:00:00Z"),
+    });
+  });
+
+  it("should skip empty legacy access code", () => {
+    const result = migrateAuthInputFromLegacyTokenState({
+      legacyTokenState: {
+        userToken: "   ",
+      },
+      migratedAt: authInput("").accessCodeEnteredAt,
+    });
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("migrateUserConfigFromLegacyState", () => {
+  it("should migrate hidden tags, colors and flags", () => {
+    const result = migrateUserConfigFromLegacyState({
+      legacyConfig: {
+        types: [{ id: 1 }, { id: 2 }],
+      },
+      legacyUserSettings: {
+        disabledTypesIds: [1, 999],
+        customTypesColors: {
+          1: "not-a-color",
+          2: " #ABCDEF ",
+          3: "#123456",
+          abc: "#654321",
+        },
+        isRepliesCollectingEnabled: true,
+        isFansTableView: true,
+      },
+    });
+
+    expect(result).toEqual({
+      tagOverrideLookup: {
+        1: {
+          hidden: true,
+        },
+        2: {
+          colorForHighlight: "#abcdef",
+        },
+      },
+      fansDisplay: "table",
+      collectingComments: true,
+    });
+  });
+
+  it("should return undefined for legacy state equal to v2 defaults", () => {
+    const result = migrateUserConfigFromLegacyState({
+      legacyConfig: undefined,
+      legacyUserSettings: {
+        isFansTableView: false,
+        isRepliesCollectingEnabled: false,
+      },
+    });
+
+    expect(result).toEqual(undefined);
+    expect(defaultUserConfig).toEqual({
+      tagOverrideLookup: {},
+      fansDisplay: "default",
+    });
+  });
+});
+
+describe("global notification migration", () => {
+  it("should detect legacy footprint and create welcome-suppressed state", () => {
+    expect(
+      hasLegacyV1FootprintInLocalStorage({
+        popupTab: "config",
+      }),
+    ).toBe(true);
+
+    expect(
+      createGlobalNotificationsStateForLegacyV1User({
+        legacyV1Detected: true,
+        migratedAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
+      }),
+    ).toEqual({
+      announcementReadAtByCreatedAt: {},
+      welcomeMessageShownAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
+      welcomeMessageReadAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
+    });
+  });
+
+  it("should skip welcome suppression when no legacy footprint exists", () => {
+    expect(hasLegacyV1FootprintInLocalStorage({})).toBe(false);
+
+    expect(
+      createGlobalNotificationsStateForLegacyV1User({
+        legacyV1Detected: false,
+        migratedAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
+++ b/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
@@ -1,6 +1,7 @@
 import { isEqual } from "es-toolkit";
 import { z } from "zod/mini";
 
+import { getBackgroundLogger } from "@/shared/@logging/core";
 import type { AuthInput } from "@/shared/@model/auth";
 import {
   defaultUserConfig,
@@ -11,7 +12,6 @@ import {
   type IsoDateTime,
   isoDateTimeSchema,
 } from "@/shared/@primitives/temporal";
-import { getBackgroundLogger } from "@/shared/logging";
 import { omitUndefined } from "@/shared/omit-undefined";
 import { browser } from "#imports";
 

--- a/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
+++ b/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
@@ -1,0 +1,432 @@
+import { isEqual } from "es-toolkit";
+import { z } from "zod/mini";
+
+import type { AuthInput } from "@/shared/@model/auth";
+import {
+  defaultUserConfig,
+  type UserConfig,
+} from "@/shared/@model/user-config";
+import { hexColorSchema, tagIdSchema } from "@/shared/@primitives/misc";
+import {
+  type IsoDateTime,
+  isoDateTimeSchema,
+} from "@/shared/@primitives/temporal";
+import { getBackgroundLogger } from "@/shared/logging";
+import { omitUndefined } from "@/shared/omit-undefined";
+import { browser } from "#imports";
+
+const logger = getBackgroundLogger(["legacy-v1-migration"]);
+
+export const legacyLocalStorageKeys = [
+  "token-state",
+  "user_settings",
+  "config",
+  "popupTab",
+  "registration_dates",
+  "reply_collector",
+  "bot_types_counter",
+  "bot_marks_counter",
+  "bot_list_fetch_date",
+  "is_data_loading",
+  "notification_log",
+  "last_closed_notification",
+  "closed_notification_data",
+  "lastConfigLoad",
+  "localBotListVersion",
+  "lastTokenRecheck",
+] as const;
+
+export const legacyAlarmNames = ["10 minutes", "weekly"] as const;
+// cspell:ignore gosvon
+export const legacyIndexedDbName = "gosvon";
+
+const legacyTokenStateSchema = z.readonly(
+  z.object({
+    userToken: z.string(),
+  }),
+);
+
+const legacyUserSettingsSchema = z.readonly(
+  z.object({
+    disabledTypesIds: z.exactOptional(
+      z.array(z.number().check(z.int(), z.nonnegative())),
+    ),
+    customTypesColors: z.exactOptional(z.record(z.string(), z.string())),
+    isRepliesCollectingEnabled: z.exactOptional(z.boolean()),
+    isFansTableView: z.exactOptional(z.boolean()),
+  }),
+);
+
+const legacyConfigSchema = z.readonly(
+  z.object({
+    types: z.array(
+      z.object({
+        id: z.number().check(z.int(), z.nonnegative()),
+      }),
+    ),
+  }),
+);
+
+type LegacyTokenState = z.infer<typeof legacyTokenStateSchema>;
+type LegacyUserSettings = z.infer<typeof legacyUserSettingsSchema>;
+type LegacyConfig = z.infer<typeof legacyConfigSchema>;
+
+type GlobalNotificationsMigrationState = Readonly<{
+  announcementReadAtByCreatedAt: Record<string, IsoDateTime>;
+  welcomeMessageShownAt: IsoDateTime;
+  welcomeMessageReadAt: IsoDateTime;
+}>;
+
+function parseLegacyValue<T extends z.ZodMiniType>(
+  schema: T,
+  value: unknown,
+  label: string,
+): z.infer<T> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    logger.warn("Skipping invalid legacy value {label}: {error}", {
+      label,
+      error: result.error.message,
+    });
+    return undefined;
+  }
+
+  return result.data;
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function getLocalStorageValues(
+  keys: string | readonly string[],
+): Promise<Record<string, unknown>> {
+  return await browser.storage.local.get(
+    typeof keys === "string" ? keys : [...keys],
+  );
+}
+
+async function removeLocalStorageValues(
+  keys: readonly string[],
+): Promise<void> {
+  await browser.storage.local.remove([...keys]);
+}
+
+async function clearAlarm(alarmName: string): Promise<boolean> {
+  return await browser.alarms.clear(alarmName);
+}
+
+async function getAlarm(alarmName: string): Promise<unknown> {
+  return await browser.alarms.get(alarmName);
+}
+
+function createAllowedLegacyTypeIdSet(
+  legacyConfig: LegacyConfig | undefined,
+): ReadonlySet<number> | undefined {
+  if (!legacyConfig || legacyConfig.types.length === 0) {
+    return undefined;
+  }
+
+  return new Set(legacyConfig.types.map((type) => type.id));
+}
+
+export function migrateAuthInputFromLegacyTokenState({
+  legacyTokenState,
+  migratedAt,
+}: {
+  legacyTokenState: LegacyTokenState | undefined;
+  migratedAt: IsoDateTime;
+}): AuthInput | undefined {
+  if (!legacyTokenState) {
+    return undefined;
+  }
+
+  const accessCode = legacyTokenState.userToken.trim().slice(0, 1000);
+  if (accessCode.length === 0) {
+    return undefined;
+  }
+
+  return {
+    accessCode,
+    accessCodeEnteredAt: migratedAt,
+  };
+}
+
+export function migrateUserConfigFromLegacyState({
+  legacyConfig,
+  legacyUserSettings,
+}: {
+  legacyConfig: LegacyConfig | undefined;
+  legacyUserSettings: LegacyUserSettings | undefined;
+}): UserConfig | undefined {
+  if (!legacyUserSettings) {
+    return undefined;
+  }
+
+  const allowedLegacyTypeIds = createAllowedLegacyTypeIdSet(legacyConfig);
+  const tagOverrideLookup = { ...defaultUserConfig.tagOverrideLookup };
+
+  function shouldUseLegacyTypeId(typeId: number): boolean {
+    return allowedLegacyTypeIds?.has(typeId) ?? true;
+  }
+
+  function upsertTagOverride(
+    rawTypeId: number,
+    override: {
+      colorForHighlight?: z.infer<typeof hexColorSchema>;
+      hidden?: true;
+    },
+  ): void {
+    if (!shouldUseLegacyTypeId(rawTypeId)) {
+      return;
+    }
+
+    const tagIdResult = tagIdSchema.safeParse(String(rawTypeId));
+    if (!tagIdResult.success) {
+      return;
+    }
+
+    const tagId = tagIdResult.data;
+    const currentOverride = tagOverrideLookup[tagId] ?? {};
+    tagOverrideLookup[tagId] = omitUndefined({
+      hidden: currentOverride.hidden ?? override.hidden,
+      colorForHighlight:
+        currentOverride.colorForHighlight ?? override.colorForHighlight,
+    });
+  }
+
+  for (const rawTypeId of legacyUserSettings.disabledTypesIds ?? []) {
+    upsertTagOverride(rawTypeId, { hidden: true });
+  }
+
+  for (const [rawTypeId, rawColor] of Object.entries(
+    legacyUserSettings.customTypesColors ?? {},
+  )) {
+    const typeId = Number(rawTypeId);
+    if (!Number.isInteger(typeId) || typeId < 0) {
+      continue;
+    }
+
+    const colorResult = hexColorSchema.safeParse(rawColor.trim().toLowerCase());
+    if (!colorResult.success) {
+      continue;
+    }
+
+    upsertTagOverride(typeId, { colorForHighlight: colorResult.data });
+  }
+
+  const fansDisplay: UserConfig["fansDisplay"] =
+    legacyUserSettings.isFansTableView ? "table" : "default";
+  const collectingComments = legacyUserSettings.isRepliesCollectingEnabled
+    ? true
+    : undefined;
+
+  const migratedUserConfig: UserConfig = omitUndefined({
+    tagOverrideLookup,
+    fansDisplay,
+    collectingComments,
+  });
+
+  return isEqual(migratedUserConfig, defaultUserConfig)
+    ? undefined
+    : migratedUserConfig;
+}
+
+export function hasLegacyV1FootprintInLocalStorage(
+  rawLegacyState: Partial<
+    Record<(typeof legacyLocalStorageKeys)[number], unknown>
+  >,
+): boolean {
+  return legacyLocalStorageKeys.some((key) =>
+    Object.hasOwn(rawLegacyState, key),
+  );
+}
+
+export function createGlobalNotificationsStateForLegacyV1User({
+  legacyV1Detected,
+  migratedAt,
+}: {
+  legacyV1Detected: boolean;
+  migratedAt: IsoDateTime;
+}): GlobalNotificationsMigrationState | undefined {
+  if (!legacyV1Detected) {
+    return undefined;
+  }
+
+  return {
+    announcementReadAtByCreatedAt: {},
+    welcomeMessageShownAt: migratedAt,
+    welcomeMessageReadAt: migratedAt,
+  };
+}
+
+export async function migrateAuthInputFromV1(): Promise<AuthInput | undefined> {
+  let rawLegacyState: Record<string, unknown>;
+  try {
+    rawLegacyState = await getLocalStorageValues("token-state");
+  } catch (error) {
+    logger.warn("Failed to read legacy value token-state: {error}", {
+      error: formatErrorMessage(error),
+    });
+    return undefined;
+  }
+
+  return migrateAuthInputFromLegacyTokenState({
+    legacyTokenState: parseLegacyValue(
+      legacyTokenStateSchema,
+      rawLegacyState["token-state"],
+      "token-state",
+    ),
+    migratedAt: isoDateTimeSchema.parse(undefined),
+  });
+}
+
+export async function migrateUserConfigFromV1(): Promise<
+  UserConfig | undefined
+> {
+  let rawLegacyState: Record<string, unknown>;
+  try {
+    rawLegacyState = await getLocalStorageValues(["config", "user_settings"]);
+  } catch (error) {
+    logger.warn("Failed to read legacy values config/user_settings: {error}", {
+      error: formatErrorMessage(error),
+    });
+    return undefined;
+  }
+
+  return migrateUserConfigFromLegacyState({
+    legacyConfig: parseLegacyValue(
+      legacyConfigSchema,
+      rawLegacyState["config"],
+      "config",
+    ),
+    legacyUserSettings: parseLegacyValue(
+      legacyUserSettingsSchema,
+      rawLegacyState["user_settings"],
+      "user_settings",
+    ),
+  });
+}
+
+export async function migrateGlobalNotificationsStateFromV1(): Promise<
+  GlobalNotificationsMigrationState | undefined
+> {
+  let rawLegacyState: Record<string, unknown>;
+  try {
+    rawLegacyState = await getLocalStorageValues([...legacyLocalStorageKeys]);
+  } catch (error) {
+    logger.warn("Failed to read legacy footprint from local storage: {error}", {
+      error: formatErrorMessage(error),
+    });
+    return undefined;
+  }
+
+  return createGlobalNotificationsStateForLegacyV1User({
+    legacyV1Detected: hasLegacyV1FootprintInLocalStorage(rawLegacyState),
+    migratedAt: isoDateTimeSchema.parse(undefined),
+  });
+}
+
+async function removeLegacyLocalStorageKeys(): Promise<boolean> {
+  let remaining: Record<string, unknown>;
+  try {
+    await removeLocalStorageValues(legacyLocalStorageKeys);
+    remaining = await getLocalStorageValues([...legacyLocalStorageKeys]);
+  } catch (error) {
+    logger.warn("Failed to remove legacy local storage keys: {error}", {
+      error: formatErrorMessage(error),
+    });
+    return false;
+  }
+
+  return legacyLocalStorageKeys.every((key) => !Object.hasOwn(remaining, key));
+}
+
+async function clearLegacyAlarms(): Promise<boolean> {
+  let alarms: unknown[];
+  try {
+    await Promise.all(
+      legacyAlarmNames.map((alarmName) => clearAlarm(alarmName)),
+    );
+
+    alarms = await Promise.all(
+      legacyAlarmNames.map((alarmName) => getAlarm(alarmName)),
+    );
+  } catch (error) {
+    logger.warn("Failed to clear legacy alarms: {error}", {
+      error: formatErrorMessage(error),
+    });
+    return false;
+  }
+
+  return alarms.every((alarm) => alarm === undefined);
+}
+
+async function deleteLegacyIndexedDb(): Promise<boolean> {
+  if (typeof indexedDB === "undefined") {
+    logger.warn("indexedDB is unavailable, skipping legacy DB cleanup");
+    return false;
+  }
+
+  // cspell:ignore IDBOpenDBRequest
+  let request: IDBOpenDBRequest;
+  try {
+    request = indexedDB.deleteDatabase(legacyIndexedDbName);
+  } catch (error) {
+    logger.warn("Failed to start deleting legacy IndexedDB {dbName}: {error}", {
+      dbName: legacyIndexedDbName,
+      error: formatErrorMessage(error),
+    });
+    return false;
+  }
+
+  const { promise, resolve } = Promise.withResolvers<boolean>();
+
+  request.addEventListener("success", () => {
+    resolve(true);
+  });
+
+  request.addEventListener("error", () => {
+    logger.warn("Failed to delete legacy IndexedDB {dbName}: {error}", {
+      dbName: legacyIndexedDbName,
+      error: request.error?.message,
+    });
+    resolve(false);
+  });
+
+  request.addEventListener("blocked", () => {
+    logger.warn("Deletion of legacy IndexedDB {dbName} was blocked", {
+      dbName: legacyIndexedDbName,
+    });
+    resolve(false);
+  });
+
+  return await promise;
+}
+
+export async function cleanupLegacyV1State(): Promise<void> {
+  const [localStorageRemoved, alarmsCleared, indexedDbDeleted] =
+    await Promise.all([
+      removeLegacyLocalStorageKeys(),
+      clearLegacyAlarms(),
+      deleteLegacyIndexedDb(),
+    ]);
+
+  if (!localStorageRemoved || !alarmsCleared || !indexedDbDeleted) {
+    logger.warn(
+      "Legacy v1 cleanup remains incomplete (localStorageRemoved={localStorageRemoved}, alarmsCleared={alarmsCleared}, indexedDbDeleted={indexedDbDeleted})",
+      {
+        localStorageRemoved,
+        alarmsCleared,
+        indexedDbDeleted,
+      },
+    );
+    return;
+  }
+
+  logger.info("Legacy v1 cleanup completed");
+}

--- a/src/entrypoints/background/@services/notification-service.ts
+++ b/src/entrypoints/background/@services/notification-service.ts
@@ -18,8 +18,10 @@ import {
   type IsoDateTime,
   isoDateTimeSchema,
 } from "@/shared/@primitives/temporal";
+import { getBackgroundLogger } from "@/shared/logging";
 
 import { defineStoreWithSchema } from "../@service-helpers/store-with-schema";
+import { migrateGlobalNotificationsStateFromV1 } from "./legacy-v1-migration-helpers";
 
 const globalNotificationsStateSchema = z.readonly(
   z.object({
@@ -33,9 +35,13 @@ const globalNotificationsStateSchema = z.readonly(
 
 type GlobalNotificationsState = z.infer<typeof globalNotificationsStateSchema>;
 
+const logger = getBackgroundLogger(["notification-service"]);
+
+// TODO: Remove `migrateDataFromV1` after the v1 -> v2 upgrade window closes.
 const globalNotificationsStore = defineStoreWithSchema(
   "sync:global-notifications",
   globalNotificationsStateSchema,
+  { migrateDataFromV1: migrateGlobalNotificationsStateFromV1 },
 );
 
 const defaultGlobalNotificationsState: GlobalNotificationsState = {
@@ -60,22 +66,19 @@ const triggeredNotificationsStore = defineStoreWithSchema(
 );
 
 export class NotificationService {
-  private pollableGlobalNotificationsState: Pollable<GlobalNotificationsState>;
+  private pollableGlobalNotificationsState: Pollable<
+    GlobalNotificationsState | undefined
+  >;
   private pollableTriggeredNotificationByContentId: Record<
     ContentId,
     Pollable<TriggeredNotification | undefined>
   > = {};
 
   constructor() {
-    this.pollableGlobalNotificationsState = new Pollable(
-      defaultGlobalNotificationsState,
-    );
-
-    void globalNotificationsStore.getValue().then((value) => {
-      if (value) {
-        this.pollableGlobalNotificationsState.setValue(value);
-      }
-    });
+    this.pollableGlobalNotificationsState = new Pollable<
+      GlobalNotificationsState | undefined
+    >(undefined);
+    void this.startLoadingGlobalNotificationsStateWithStore();
 
     void triggeredNotificationsStore.getValue().then((value) => {
       if (value) {
@@ -94,6 +97,22 @@ export class NotificationService {
         }
       }
     });
+  }
+
+  private async startLoadingGlobalNotificationsStateWithStore() {
+    try {
+      this.pollableGlobalNotificationsState.setValue(
+        (await globalNotificationsStore.getValue()) ??
+          defaultGlobalNotificationsState,
+      );
+    } catch (error) {
+      logger.error("Failed to initialize global notifications state: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.pollableGlobalNotificationsState.setValue(
+        defaultGlobalNotificationsState,
+      );
+    }
   }
 
   async pollTriggeredNotification(
@@ -152,6 +171,13 @@ export class NotificationService {
     update: Producer<GlobalNotificationsState>,
   ): void {
     const oldState = this.pollableGlobalNotificationsState.getValue();
+    if (!oldState) {
+      logger.warn(
+        "Skipping global notifications update before store initialization",
+      );
+      return;
+    }
+
     const newState = produce(oldState, update);
 
     if (isEqual(newState, oldState)) {
@@ -182,9 +208,25 @@ export class NotificationService {
     });
   }
 
+  async getGlobalNotificationsState(): Promise<GlobalNotificationsState> {
+    const result = await this.pollGlobalNotificationsState(undefined);
+    return result.value;
+  }
+
   async pollGlobalNotificationsState(
     lastPollVersion: PollVersion | undefined,
   ): Promise<PollResult<GlobalNotificationsState>> {
-    return this.pollableGlobalNotificationsState.poll(lastPollVersion);
+    let result:
+      | PollResult<GlobalNotificationsState>
+      | PollResult<undefined>
+      | undefined;
+
+    do {
+      result = await this.pollableGlobalNotificationsState.poll(
+        lastPollVersion ?? result?.version,
+      );
+    } while (!result?.value);
+
+    return result;
   }
 }

--- a/src/entrypoints/background/@services/notification-service.ts
+++ b/src/entrypoints/background/@services/notification-service.ts
@@ -3,6 +3,7 @@ import { produce, type Producer } from "immer";
 import type { WritableDeep } from "type-fest";
 import { z } from "zod/mini";
 
+import { getBackgroundLogger } from "@/shared/@logging/core";
 import {
   type TriggeredNotification,
   type TriggeredNotificationPayload,
@@ -18,7 +19,6 @@ import {
   type IsoDateTime,
   isoDateTimeSchema,
 } from "@/shared/@primitives/temporal";
-import { getBackgroundLogger } from "@/shared/logging";
 
 import { defineStoreWithSchema } from "../@service-helpers/store-with-schema";
 import { migrateGlobalNotificationsStateFromV1 } from "./legacy-v1-migration-helpers";

--- a/src/entrypoints/background/@services/user-config-service.ts
+++ b/src/entrypoints/background/@services/user-config-service.ts
@@ -13,12 +13,15 @@ import {
 } from "@/shared/@pollable/core";
 
 import { defineStoreWithSchema } from "../@service-helpers/store-with-schema";
+import { migrateUserConfigFromV1 } from "./legacy-v1-migration-helpers";
 
 const logger = getBackgroundLogger(["user-config-service"]);
 
+// TODO: Remove `migrateDataFromV1` after the v1 -> v2 upgrade window closes.
 const userConfigStore = defineStoreWithSchema(
   "sync:user-config",
   userConfigSchema,
+  { migrateDataFromV1: migrateUserConfigFromV1 },
 );
 
 export class UserConfigService {


### PR DESCRIPTION
Добавлена логику для пользователей v1.x. При старте v2.x:
1. существующие значения v1.x мигрируются в v2.x (настройки подсветки, код доступа, настройка сбора комментариев, табличный вид лайков)
2. данные для v1.x стираются, чтобы очистить место на диске

Код для миграции данных удалим через пару месяцев после релиза 2.0.0 (у браузеров будет достаточно времени, чтобы всех мигрировать).