### PR TITLE
Don't cancel CI on push if still in progress

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,6 @@ on:
       - main
     tags: ["*"]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 env:
   ARTIFACT_RETENTION_DAYS_PR: 2
   ARTIFACT_RETENTION_DAYS_MAIN: 30


### PR DESCRIPTION
Публичные ранеры бесплатные, так что нет смысла их тормозить. Статус коммитов в ПР становится понятнее и не зависит от времени пуша (меньше ×, больше ✔️)