### PR TITLE
Enable announcement of v2.0.0 in a toast after v1 data migration

### DIFF
--- a/src/entrypoints/background/@services/legacy-v1-migration-helpers.test.ts
+++ b/src/entrypoints/background/@services/legacy-v1-migration-helpers.test.ts
@@ -5,8 +5,6 @@ import { defaultUserConfig } from "@/shared/@model/user-config";
 import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
 
 import {
-  createGlobalNotificationsStateForLegacyV1User,
-  hasLegacyV1FootprintInLocalStorage,
   migrateAuthInputFromLegacyTokenState,
   migrateUserConfigFromLegacyState,
 } from "./legacy-v1-migration-helpers";
@@ -92,37 +90,5 @@ describe("migrateUserConfigFromLegacyState", () => {
       tagOverrideLookup: {},
       fansDisplay: "default",
     });
-  });
-});
-
-describe("global notification migration", () => {
-  it("should detect legacy footprint and create welcome-suppressed state", () => {
-    expect(
-      hasLegacyV1FootprintInLocalStorage({
-        popupTab: "config",
-      }),
-    ).toBe(true);
-
-    expect(
-      createGlobalNotificationsStateForLegacyV1User({
-        legacyV1Detected: true,
-        migratedAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
-      }),
-    ).toEqual({
-      announcementReadAtByCreatedAt: {},
-      welcomeMessageShownAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
-      welcomeMessageReadAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
-    });
-  });
-
-  it("should skip welcome suppression when no legacy footprint exists", () => {
-    expect(hasLegacyV1FootprintInLocalStorage({})).toBe(false);
-
-    expect(
-      createGlobalNotificationsStateForLegacyV1User({
-        legacyV1Detected: false,
-        migratedAt: isoDateTimeSchema.parse("2024-03-01T00:00:00Z"),
-      }),
-    ).toBeUndefined();
   });
 });

--- a/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
+++ b/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
@@ -246,24 +246,6 @@ export function hasLegacyV1FootprintInLocalStorage(
   );
 }
 
-export function createGlobalNotificationsStateForLegacyV1User({
-  legacyV1Detected,
-  migratedAt,
-}: {
-  legacyV1Detected: boolean;
-  migratedAt: IsoDateTime;
-}): GlobalNotificationsMigrationState | undefined {
-  if (!legacyV1Detected) {
-    return undefined;
-  }
-
-  return {
-    announcementReadAtByCreatedAt: {},
-    welcomeMessageShownAt: migratedAt,
-    welcomeMessageReadAt: migratedAt,
-  };
-}
-
 export async function migrateAuthInputFromV1(): Promise<AuthInput | undefined> {
   let rawLegacyState: Record<string, unknown>;
   try {
@@ -325,10 +307,18 @@ export async function migrateGlobalNotificationsStateFromV1(): Promise<
     return undefined;
   }
 
-  return createGlobalNotificationsStateForLegacyV1User({
-    legacyV1Detected: hasLegacyV1FootprintInLocalStorage(rawLegacyState),
-    migratedAt: isoDateTimeSchema.parse(undefined),
-  });
+  if (!hasLegacyV1FootprintInLocalStorage(rawLegacyState)) {
+    return undefined;
+  }
+
+  // Using arbitrary date in the past to enable toasts with announcements from this date.
+  const isoDateTime = isoDateTimeSchema.parse("2026-01-01T00:00:00Z");
+
+  return {
+    announcementReadAtByCreatedAt: {},
+    welcomeMessageShownAt: isoDateTime,
+    welcomeMessageReadAt: isoDateTime,
+  };
 }
 
 async function removeLegacyLocalStorageKeys(): Promise<boolean> {


### PR DESCRIPTION
Подкручена логика миграции данных из v1 (#56). Помечаем _welcome toast_ как «показанный 2026-01-01» вместо «показанный только что». Это позволит людям увидеть тост с анонсом 2.0.0.