### PR TITLE
Improve data warmup toast show/hide logic

### DIFF
--- a/src/entrypoints/content/in-page-app/toasts.tsx
+++ b/src/entrypoints/content/in-page-app/toasts.tsx
@@ -105,7 +105,7 @@ export function Toasts() {
     return (
       <React.Suspense>
         <ToastWithDataWarmup
-          onClose={() => {
+          onDone={() => {
             setDataWarmupToastNeeded(false);
           }}
         />

--- a/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
+++ b/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
@@ -6,6 +6,18 @@ import { useStaticListMetadata } from "@/shared/@ui-helpers/data-hooks";
 
 import { Toast } from "./toast";
 
+// Minimum time before we even consider showing the toast.
+const showToastAfterMs = 2000;
+
+// Show the toast if the linearly-extrapolated remaining time exceeds this.
+// Example: at 2 s in with 50 % done → ~2 s estimated remaining → show.
+//          at 2 s in with 98 % done → ~40 ms estimated remaining  → skip.
+const showIfEstimatedRemainingMoreThanMs = 2000;
+
+// Also show if progress hasn't moved for this long after the initial delay.
+// Handles the case where loading sprints to a high percentage and then stalls.
+const showIfProgressStuckForMs = 2000;
+
 function extractItemCountFromRawSummary(
   summary: JsonValue | undefined,
 ): number {
@@ -18,7 +30,7 @@ function extractItemCountFromRawSummary(
   return 0;
 }
 
-export function ToastWithDataWarmup({ onClose }: { onClose: () => void }) {
+export function ToastWithDataWarmup({ onDone }: { onDone: () => void }) {
   const accountsMetadata = useStaticListMetadata("accounts");
   const insertionsMetadata = useStaticListMetadata("insertions");
   const tagsMetadata = useStaticListMetadata("tags");
@@ -27,12 +39,6 @@ export function ToastWithDataWarmup({ onClose }: { onClose: () => void }) {
     accountsMetadata.remoteActive &&
     insertionsMetadata.remoteActive &&
     tagsMetadata.remoteActive;
-
-  React.useEffect(() => {
-    if (done) {
-      onClose();
-    }
-  }, [done, onClose]);
 
   const nextExpectedItemCount =
     (accountsMetadata.remoteNext?.upstreamInfo.itemCount ?? 0) +
@@ -47,6 +53,68 @@ export function ToastWithDataWarmup({ onClose }: { onClose: () => void }) {
   const progressInPercentage = nextExpectedItemCount
     ? clamp(round((nextItemCount / nextExpectedItemCount) * 100, 1), 0, 99.9)
     : 95;
+
+  // Refs let the interval callback read the latest values without being
+  // re-registered on every render. Initialized and synced via effect -
+  // avoids calling Date.now() during render.
+  const mountTimeRef = React.useRef<number | undefined>(undefined);
+  const progressRef = React.useRef(progressInPercentage);
+  const lastProgressChangeAtRef = React.useRef<number | undefined>(undefined);
+  React.useEffect(() => {
+    const now = Date.now();
+    if (mountTimeRef.current === undefined) {
+      mountTimeRef.current = now;
+      lastProgressChangeAtRef.current = now;
+    } else if (progressInPercentage !== progressRef.current) {
+      lastProgressChangeAtRef.current = now;
+    }
+    progressRef.current = progressInPercentage;
+  });
+
+  const [shouldShow, setShouldShow] = React.useState(false);
+
+  React.useEffect(() => {
+    function check() {
+      const mountTime = mountTimeRef.current;
+      const lastProgressChangeAt = lastProgressChangeAtRef.current;
+      if (mountTime === undefined || lastProgressChangeAt === undefined) {
+        return;
+      }
+
+      const now = Date.now();
+      const elapsed = now - mountTime;
+      if (elapsed < showToastAfterMs) {
+        return;
+      }
+
+      const progress = progressRef.current;
+      const estimatedRemaining =
+        progress > 0 ? (elapsed * (100 - progress)) / progress : Infinity;
+      const timeSinceProgressChange = now - lastProgressChangeAt;
+
+      if (
+        estimatedRemaining > showIfEstimatedRemainingMoreThanMs ||
+        timeSinceProgressChange > showIfProgressStuckForMs
+      ) {
+        setShouldShow(true);
+      }
+    }
+
+    const interval = setInterval(check, 500);
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (done) {
+      onDone();
+    }
+  }, [done, onDone]);
+
+  if (!shouldShow) {
+    return;
+  }
 
   return (
     <Toast>


### PR DESCRIPTION
Тост с прогрессом загрузки данных переработан, чтобы не мелькать при быстрой загрузке и при этом всё равно появляться, если загрузка зависла.

- Тост показывается только если расчётное оставшееся время превышает 2 с (линейная экстраполяция по текущему прогрессу и прошедшему времени)
- Дополнительно тост появляется, если прогресс не двигался дольше 2 с после первых 2 с с момента монтирования — это покрывает случай, когда загрузка быстро достигает высокого процента и затем зависает
- Проверка выполняется каждые 500 мс через интервал
- Проп onClose переименован в onDone; он срабатывает сразу при завершении загрузки, даже если тост так и не был показан