### PR TITLE
Use RUNNER_LABEL repo var for runs-on in all workflows

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     name: Create Release Draft
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-24.04' }}
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-24.04' }}
     permissions:
       actions: write
       contents: read
@@ -151,7 +151,7 @@ jobs:
 
   lint-and-test:
     name: Lint and Test
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   labeler:
     name: Apply path labels
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-24.04' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   sync-root-config-seed:
     name: Sync root config seed
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-24.04' }}
     if: github.repository_owner == 'botnadzor'
 
     env:


### PR DESCRIPTION
В настройках репозитория теперь можно задать переменную `RUNNER_LABEL`, чтобы выбрать, на каком runner'е запускать CI.

**Settings → Secrets and variables → Actions → Variables → New repository variable**

| Значение | Где запускается |
|---|---|
| `self-hosted` | наш собственный runner |
| `ubuntu-24.04` | GitHub-hosted runner |

Если переменная не задана — используется `ubuntu-24.04`.