### PR TITLE
Refactor static lists service

### DIFF
--- a/cspell-words.txt
+++ b/cspell-words.txt
@@ -1,4 +1,5 @@
 add-ons
+bivariance
 botnadzor
 btn
 callees
@@ -15,6 +16,8 @@ esbuild
 firefox
 github
 HMR
+IDB
+inspectable
 jsonrepair
 keyof
 knip
@@ -35,6 +38,7 @@ orpc
 oxc-resolver
 pnpm-dedupe
 pollable
+redownload
 repost
 rowsmembers
 rsc
@@ -50,6 +54,8 @@ tailwindcss
 testid
 tsc
 unmutate
+Unvalidated
+upserts
 userrichcell
 vesti
 vite

--- a/scripts/dump-curated-static-lists.script.ts
+++ b/scripts/dump-curated-static-lists.script.ts
@@ -3,8 +3,8 @@
  *
  * For each .ts file in src/curated-static-lists/, the script:
  * 1. Extracts the default-exported array from the TypeScript source
- * 2. Validates each item against the list definition's storedItemSchema
- * 3. Converts data to received format using mapStoredToReceived()
+ * 2. Validates each item against the list definition's interpretedItemSchema
+ * 3. Converts data to JSONL format using serializeInterpretedItemAsJsonl()
  * 4. Writes JSONL output to dist/curated-static-lists/{listId}.jsonl
  *
  * Usage: npx tsx scripts/dump-curated-static-lists.script.ts
@@ -15,7 +15,6 @@ import path from "node:path";
 
 import { staticListIdSchema } from "@/shared/@model/dx-config";
 import { extractCuratedListFromTs } from "@/shared/@model/static-list-extraction";
-import type { StaticListDefinition } from "@/shared/@model/static-list-helpers";
 import {
   staticListDefinitionLookup,
   staticListIds,
@@ -49,7 +48,7 @@ async function main() {
     }
 
     const listId = listIdResult.data;
-    const definition: StaticListDefinition = staticListDefinitionLookup[listId];
+    const definition = staticListDefinitionLookup[listId];
 
     logger.log(`Processing ${tsFile}...`);
 
@@ -63,9 +62,9 @@ async function main() {
       );
     }
 
-    const storedItems: Array<Record<string, unknown>> = [];
+    const interpretedItems: Array<Record<string, unknown>> = [];
     for (const [index, rawItem] of rawItems.entries()) {
-      const parseResult = definition.storedItemSchema.safeParse(rawItem);
+      const parseResult = definition.interpretedItemSchema.safeParse(rawItem);
       if (!parseResult.success) {
         const messages = parseResult.error.issues
           .map(
@@ -77,12 +76,12 @@ async function main() {
         );
       }
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- safeParse result is a validated object
-      storedItems.push(parseResult.data as Record<string, unknown>);
+      interpretedItems.push(parseResult.data as Record<string, unknown>);
     }
 
-    if (definition.jsonlRowSortingBy) {
-      const sortingKeys = definition.jsonlRowSortingBy;
-      storedItems.sort((a, b) => {
+    if (definition.jsonlExportSortingBy) {
+      const sortingKeys = definition.jsonlExportSortingBy;
+      interpretedItems.sort((a, b) => {
         for (const key of sortingKeys) {
           const aVal = String(a[key]);
           const bVal = String(b[key]);
@@ -98,11 +97,16 @@ async function main() {
     }
 
     const jsonlLines: string[] = [];
-    for (const storedItem of storedItems) {
-      const receivedItem = definition.mapStoredToReceived(storedItem);
-      const line =
-        definition.jsonlStringifyRow?.(receivedItem) ??
-        JSON.stringify(receivedItem);
+    /* eslint-disable @typescript-eslint/consistent-type-assertions -- each item in interpretedItems was validated against this exact definition above */
+    const serializeInterpretedItemAsJsonl =
+      definition.serializeInterpretedItemAsJsonl as (item: unknown) => unknown;
+    const jsonlStringifyRow = definition.jsonlStringifyRow as
+      | ((item: unknown) => string)
+      | undefined;
+    /* eslint-enable @typescript-eslint/consistent-type-assertions -- re-enable after bridging the validated definition callbacks */
+    for (const interpretedItem of interpretedItems) {
+      const jsonlItem = serializeInterpretedItemAsJsonl(interpretedItem);
+      const line = jsonlStringifyRow?.(jsonlItem) ?? JSON.stringify(jsonlItem);
       jsonlLines.push(line);
     }
 

--- a/src/curated-static-lists/announcements.ts
+++ b/src/curated-static-lists/announcements.ts
@@ -1,6 +1,6 @@
 import type { z } from "zod/mini";
 
-import type { storedAnnouncementListItemSchema } from "@/shared/@model/static-lists/=announcements";
+import type { interpretedAnnouncementListItemSchema } from "@/shared/@model/static-lists/=announcements";
 
 export default [
   {
@@ -10,4 +10,4 @@ export default [
     content:
       "Рады представить вам новую версию расширения! В ней мы переработали внутреннее устройство функционирования расширения и подготовили его для работы с постоянно растущим количеством аккаунтов для подсветки",
   },
-] satisfies Array<z.input<typeof storedAnnouncementListItemSchema>>;
+] satisfies Array<z.input<typeof interpretedAnnouncementListItemSchema>>;

--- a/src/entrypoints/background/@services/static-lists-service.ts
+++ b/src/entrypoints/background/@services/static-lists-service.ts
@@ -1,23 +1,15 @@
 import type { Logger } from "@logtape/logtape";
-import { Dexie, type Table } from "dexie";
-import { delay } from "es-toolkit";
-import { nanoid } from "nanoid";
+import type { IndexableType, Table } from "dexie";
 import type { Writable, WritableDeep } from "type-fest";
 import type { z } from "zod/mini";
 
 import { getBackgroundLogger } from "@/shared/@logging/categories";
 import type {
   StaticListCombiningMode,
-  StaticListDefinition,
   StaticListItemOrigin,
-  StaticListRemoteInstance,
 } from "@/shared/@model/static-list-helpers";
+import type { StaticListMetadata } from "@/shared/@model/static-list-metadata";
 import {
-  type StaticListMetadata,
-  staticListMetadataSchema,
-} from "@/shared/@model/static-list-metadata";
-import {
-  staticListDefinitionEntries,
   staticListDefinitionLookup,
   type StaticListId,
   staticListIds,
@@ -37,135 +29,50 @@ import {
 import type { AliasManager } from "../@service-helpers/alias-manager";
 import { fetchFromRemoteSystem } from "../@service-helpers/fetch-from-remote-system";
 import type { RootConfigService } from "./root-config-service";
+import {
+  getStaticListDefinitionInfo,
+  type StaticListDefinitionInfo,
+} from "./static-lists-service/definition-helpers";
+import { interpretStoredRow } from "./static-lists-service/interpretation";
+import {
+  StaticListDatabases,
+  type StaticListRowsDatabase,
+} from "./static-lists-service/list-database";
+import {
+  createDefaultStaticListMetadata,
+  extractSummaryFromMetadata,
+  extractUpdatedAtFromMetadata,
+  getStaticListMetadataStore,
+  pickAnotherRemoteInstance,
+  shouldComputeDevSummaries,
+  tryExtractSummaryFromMetadata,
+  tryParseStaticListMetadata,
+} from "./static-lists-service/metadata-helpers";
+import {
+  createStoredRemoteRow,
+  prepareUnvalidatedLocalRow,
+  prepareValidatedLocalRow,
+} from "./static-lists-service/row-helpers";
+import {
+  cloneEmptySummary,
+  createEmptySummary,
+  tryInterpretSummaryItemDelta,
+  withUpdatedDerivedDataVersion,
+} from "./static-lists-service/summary-helpers";
+import type {
+  LocalWriteResult,
+  RemoveLocalItemTarget,
+  StaticListPageEntry,
+  StaticListPutLocalItemsOptions,
+  StoredLocalRow,
+  StoredRemoteRow,
+} from "./static-lists-service/types";
 
 const logger = getBackgroundLogger(["static-lists-service"]);
 
 const itemBatchSize = 1000;
-const lockIntervalInMs = 100;
-const lockTimeoutInMs = 10_000;
-const metadataTableName = "--metadata--";
-
-async function* streamLines(
-  readableStream: ReadableStream<Uint8Array>,
-): AsyncGenerator<string> {
-  const decoder = new TextDecoder();
-  const reader = readableStream.getReader();
-  let { value: chunk, done } = await reader.read();
-  let buffer = "";
-  while (!done) {
-    buffer += decoder.decode(chunk, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() ?? "";
-    for (const line of lines) {
-      yield line;
-    }
-    ({ value: chunk, done } = await reader.read());
-  }
-  buffer += decoder.decode();
-  if (buffer) {
-    for (const line of buffer.split("\n")) {
-      if (line.length > 0) {
-        yield line;
-      }
-    }
-  }
-}
-
-function generateRemoteTableName(
-  listId: StaticListId,
-  instance: StaticListRemoteInstance,
-): string {
-  return `${listId}_remote_${instance}`;
-}
-
-function generateLocalTableName(listId: StaticListId): string {
-  return `${listId}_local`;
-}
-
-function pickAnotherInstance(
-  instance: StaticListRemoteInstance,
-): StaticListRemoteInstance {
-  return instance === "a" ? "b" : "a";
-}
-
-function extractSummaryFromMetadata(
-  metadata: StaticListMetadata,
-  mode: "remoteActive" | "remoteNext" = "remoteActive",
-): StaticListSummary {
-  const listId = metadata.listId;
-
-  const rawSummary = metadata[mode]?.summary;
-  const summaryResult =
-    staticListDefinitionLookup[listId].summarySchema.safeParse(rawSummary);
-
-  return (
-    summaryResult.data ??
-    staticListDefinitionLookup[listId].createEmptySummary()
-  );
-}
-
-function extractCombinedSummaryFromMetadata(
-  metadata: StaticListMetadata,
-): StaticListSummary {
-  const listId = metadata.listId;
-
-  const rawSummary = metadata.combinedSummary;
-  if (rawSummary) {
-    const summaryResult =
-      staticListDefinitionLookup[listId].summarySchema.safeParse(rawSummary);
-    if (summaryResult.data) {
-      return summaryResult.data;
-    }
-  }
-
-  return extractSummaryFromMetadata(metadata);
-}
-
-function extractLocalSummaryFromMetadata(
-  metadata: StaticListMetadata,
-): StaticListSummary {
-  const listId = metadata.listId;
-
-  const rawSummary = metadata.localSummary;
-  if (rawSummary) {
-    const summaryResult =
-      staticListDefinitionLookup[listId].summarySchema.safeParse(rawSummary);
-    if (summaryResult.data) {
-      return summaryResult.data;
-    }
-  }
-
-  return staticListDefinitionLookup[listId].createEmptySummary();
-}
-
-function extractUpdatedAtFromMetadata(
-  metadata: StaticListMetadata,
-): IsoDateTime | undefined {
-  const combiningMode = metadata.combiningMode;
-
-  if (combiningMode === "remoteOnly") {
-    return metadata.remoteActive?.updatedAt;
-  }
-
-  if (combiningMode === "localOnly") {
-    return metadata.localUpdatedAt;
-  }
-
-  // remoteWithLocalOverrides: use the most recent timestamp
-  const remoteUpdatedAt = metadata.remoteActive?.updatedAt;
-  const localUpdatedAt = metadata.localUpdatedAt;
-
-  if (!remoteUpdatedAt) {
-    return localUpdatedAt;
-  }
-
-  if (!localUpdatedAt) {
-    return remoteUpdatedAt;
-  }
-
-  // ISO date strings can be compared lexicographically
-  return [remoteUpdatedAt, localUpdatedAt].toSorted().toReversed()[0];
-}
+const maxGetItemsCount = 10_000;
+const defaultLocalRowLimit = 1000;
 
 type PopulateFromUrlIfOutdatedResult =
   | {
@@ -177,27 +84,193 @@ type PopulateFromUrlIfOutdatedResult =
       error: string;
     };
 
+type ListContext = {
+  listId: StaticListId;
+  definitionInfo: StaticListDefinitionInfo;
+  databases: StaticListDatabases;
+  metadataStore: ReturnType<typeof getStaticListMetadataStore>;
+  metadata: StaticListMetadata;
+};
+
+type PreparedLocalRowResult =
+  | { success: true; row: StoredLocalRow }
+  | { success: false; error: string; details?: unknown };
+
+async function* streamLines(
+  readableStream: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  const decoder = new TextDecoder();
+  const reader = readableStream.getReader();
+  let { value: chunk, done } = await reader.read();
+  let buffer = "";
+
+  while (!done) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      yield line;
+    }
+
+    ({ value: chunk, done } = await reader.read());
+  }
+
+  buffer += decoder.decode();
+  if (buffer.length === 0) {
+    return;
+  }
+
+  for (const line of buffer.split("\n")) {
+    if (line.length > 0) {
+      yield line;
+    }
+  }
+}
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function toIndexableType(value: IDBValidKey): IndexableType {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie's equals() API requires IndexableType, so we explicitly bridge from IDBValidKey here
+  return value as unknown as IndexableType;
+}
+
+function omitRemoteStaging<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+): StaticListMetadata<ListId> {
+  const {
+    remoteStaging: remoteStagingOmitted,
+    ...metadataWithoutRemoteStaging
+  } = metadata;
+  void remoteStagingOmitted;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- removing an exact-optional property via rest is correct at runtime but TS loses that shape
+  return metadataWithoutRemoteStaging as StaticListMetadata<ListId>;
+}
+
+function omitLocalUpdatedAt<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+): StaticListMetadata<ListId> {
+  const { localUpdatedAt: localUpdatedAtOmitted, ...metadataWithoutLocal } =
+    metadata;
+  void localUpdatedAtOmitted;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- removing an exact-optional property via rest is correct at runtime but TS loses that shape
+  return metadataWithoutLocal as StaticListMetadata<ListId>;
+}
+
+function omitRemoteActive<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+): StaticListMetadata<ListId> {
+  const { remoteActive: remoteActiveOmitted, ...metadataWithoutRemoteActive } =
+    metadata;
+  void remoteActiveOmitted;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- removing an exact-optional property via rest is correct at runtime but TS loses that shape
+  return metadataWithoutRemoteActive as StaticListMetadata<ListId>;
+}
+
+function sortLocalRows(rows: StoredLocalRow[]): StoredLocalRow[] {
+  return rows.toSorted((left, right) => {
+    if (left.u !== right.u) {
+      return right.u.localeCompare(left.u);
+    }
+
+    return left.i.localeCompare(right.i);
+  });
+}
+
+function createPageEntryFromStoredRow(
+  listId: StaticListId,
+  storedRow: StoredLocalRow | StoredRemoteRow,
+  origin: StaticListItemOrigin,
+  shadowedRemoteRowKeys: IDBValidKey[] = [],
+): StaticListPageEntry {
+  const interpretedRow = interpretStoredRow(listId, storedRow, origin);
+
+  return {
+    rowKey: interpretedRow.rowKey,
+    origin,
+    logicalPrimaryKey: interpretedRow.logicalPrimaryKey,
+    indexValues: interpretedRow.cachedIndexValues,
+    sourceText: interpretedRow.sourceText,
+    sourceItem: interpretedRow.sourceItem,
+    interpretation: interpretedRow.interpretation,
+    shadowedRemoteRowKeys,
+  };
+}
+
+function coerceLegacyRemoveLocalItemTarget(
+  listId: StaticListId,
+  targetOrIndex: RemoveLocalItemTarget | string,
+  value?: unknown,
+): RemoveLocalItemTarget {
+  if (typeof targetOrIndex === "object") {
+    return targetOrIndex;
+  }
+
+  const definitionInfo = getStaticListDefinitionInfo(listId);
+  if (targetOrIndex !== definitionInfo.logicalPrimaryKeySlot.definition.name) {
+    // eslint-disable-next-line no-restricted-syntax -- invalid legacy index usage is a programmer error and should fail loudly
+    throw new Error(
+      `Unsupported legacy removeLocalItem index "${targetOrIndex}" for ${listId}`,
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the legacy overload only supports the logical primary key, which is always an IDB-valid key
+  return { logicalPrimaryKey: value as IDBValidKey };
+}
+
+/**
+ * Static lists persist remote rows as raw JSONL source and interpret them only
+ * when something reads them.
+ *
+ * That split is the main architectural choice behind this rewrite:
+ *
+ * - remote storage stays source-preserving across extension upgrades
+ * - `derivedDataVersion` can force a cheap redownload instead of a DB rebuild
+ * - malformed remote/local rows remain inspectable in the sidepanel
+ * - local/combined summaries stay in memory so `remoteOnly` avoids dev-only
+ *   overhead
+ */
 export class StaticListsService {
   private readonly aliasManagerForStaticApi: AliasManager;
   private readonly rootConfigService: RootConfigService;
   private disposed = false;
-  private readonly db: Dexie;
 
-  private pollableListMetadataByListId: Readonly<
+  private readonly contextByListId = new Map<StaticListId, ListContext>();
+  private readonly initializationPromiseByListId = new Map<
+    StaticListId,
+    Promise<ListContext>
+  >();
+  private readonly updatePromiseByListId = new Map<
+    StaticListId,
+    Promise<PopulateFromUrlIfOutdatedResult>
+  >();
+  private readonly localMutationTailByListId = new Map<
+    StaticListId,
+    Promise<void>
+  >();
+
+  private readonly localSummaryByListId = new Map<
+    StaticListId,
+    StaticListSummary
+  >();
+  private readonly combinedSummaryByListId = new Map<
+    StaticListId,
+    StaticListSummary
+  >();
+
+  private readonly pollableListMetadataByListId: Readonly<
     Record<StaticListId, Pollable<StaticListMetadata | undefined>>
   >;
-
-  private pollableListSummaryByListId: Readonly<
+  private readonly pollableListSummaryByListId: Readonly<
     Record<StaticListId, Pollable<StaticListSummary | undefined>>
   >;
-  private pollableRemoteNextListSummaryByListId: Readonly<
+  private readonly pollableRemoteStagingSummaryByListId: Readonly<
     Record<StaticListId, Pollable<StaticListSummary | undefined>>
   >;
-  private pollableListUpdatedAtByListId: Readonly<
+  private readonly pollableListUpdatedAtByListId: Readonly<
     Record<StaticListId, Pollable<IsoDateTime | undefined>>
   >;
-
-  private readonly metadataWriteThrottleMs = 500;
 
   constructor({
     aliasManagerForStaticApi,
@@ -209,39 +282,15 @@ export class StaticListsService {
     this.aliasManagerForStaticApi = aliasManagerForStaticApi;
     this.rootConfigService = rootConfigService;
 
-    this.db = new Dexie("static-lists");
-    this.db.version(2).stores({
-      [metadataTableName]: "listId",
-      ...Object.fromEntries(
-        staticListDefinitionEntries.flatMap(([listId, listDefinition]) => [
-          [
-            generateRemoteTableName(listId, "a"),
-            ["++", ...listDefinition.indexes].join(","),
-          ],
-          [
-            generateRemoteTableName(listId, "b"),
-            ["++", ...listDefinition.indexes].join(","),
-          ],
-          [
-            generateLocalTableName(listId),
-            ["++", ...listDefinition.indexes].join(","),
-          ],
-        ]),
-      ),
-    });
-
     const pollableListMetadataByListId: Writable<
       Partial<typeof this.pollableListMetadataByListId>
     > = {};
-
     const pollableListSummaryByListId: Writable<
       Partial<typeof this.pollableListSummaryByListId>
     > = {};
-
-    const pollableRemoteNextListSummaryByListId: Writable<
-      Partial<typeof this.pollableRemoteNextListSummaryByListId>
+    const pollableRemoteStagingSummaryByListId: Writable<
+      Partial<typeof this.pollableRemoteStagingSummaryByListId>
     > = {};
-
     const pollableListUpdatedAtByListId: Writable<
       Partial<typeof this.pollableListUpdatedAtByListId>
     > = {};
@@ -250,97 +299,36 @@ export class StaticListsService {
       pollableListMetadataByListId[listId] = new Pollable<
         StaticListMetadata | undefined
       >(undefined);
-
       pollableListSummaryByListId[listId] = new Pollable<
         StaticListSummary | undefined
       >(undefined);
-
-      pollableRemoteNextListSummaryByListId[listId] = new Pollable<
+      pollableRemoteStagingSummaryByListId[listId] = new Pollable<
         StaticListSummary | undefined
       >(undefined);
-
       pollableListUpdatedAtByListId[listId] = new Pollable<
         IsoDateTime | undefined
       >(undefined);
     }
 
     this.pollableListMetadataByListId =
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- converting partial record to a finished one after a loop
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the constructor fully populates each per-list pollable map before freezing it onto readonly fields
       pollableListMetadataByListId as typeof this.pollableListMetadataByListId;
-
     this.pollableListSummaryByListId =
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- converting partial record to a finished one after a loop
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the constructor fully populates each per-list pollable map before freezing it onto readonly fields
       pollableListSummaryByListId as typeof this.pollableListSummaryByListId;
-
-    this.pollableRemoteNextListSummaryByListId =
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- converting partial record to a finished one after a loop
-      pollableRemoteNextListSummaryByListId as typeof this.pollableRemoteNextListSummaryByListId;
-
+    this.pollableRemoteStagingSummaryByListId =
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the constructor fully populates each per-list pollable map before freezing it onto readonly fields
+      pollableRemoteStagingSummaryByListId as typeof this.pollableRemoteStagingSummaryByListId;
     this.pollableListUpdatedAtByListId =
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- converting partial record to a finished one after a loop
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the constructor fully populates each per-list pollable map before freezing it onto readonly fields
       pollableListUpdatedAtByListId as typeof this.pollableListUpdatedAtByListId;
-
-    void this.startSyncingMetadataWithDb();
   }
 
   [Symbol.dispose](): void {
     this.disposed = true;
-  }
 
-  private async startSyncingMetadataWithDb() {
-    const rawMetadataRecords = await this.getMetadataTable().toArray();
-    const parsedMetadataRecords: StaticListMetadata[] = [];
-
-    for (const rawMetadataRecord of rawMetadataRecords) {
-      const metadataResult =
-        staticListMetadataSchema.safeParse(rawMetadataRecord);
-      if (!metadataResult.success) {
-        this.getMetadataLogger().warn("Read invalid metadata: {error}", {
-          error: metadataResult.error.message,
-        });
-        continue;
-      }
-      parsedMetadataRecords.push(metadataResult.data);
-    }
-
-    for (const listId of staticListIds) {
-      const metadata = parsedMetadataRecords.find(
-        (currentMetadata) => currentMetadata.listId === listId,
-      ) ?? {
-        listId,
-        remoteActiveInstance: "b",
-        combiningMode: "remoteWithLocalOverrides",
-      };
-
-      this.pollableListMetadataByListId[listId].setValue(metadata);
-      this.pollableListSummaryByListId[listId].setValue(
-        extractCombinedSummaryFromMetadata(metadata),
-      );
-
-      this.pollableRemoteNextListSummaryByListId[listId].setValue(
-        extractSummaryFromMetadata(metadata, "remoteNext"),
-      );
-
-      this.pollableListUpdatedAtByListId[listId].setValue(
-        extractUpdatedAtFromMetadata(metadata),
-      );
-    }
-
-    for (const listId of staticListIds) {
-      void this.startWritingMetadataToDbWhenChanged(listId);
-    }
-  }
-
-  private async startWritingMetadataToDbWhenChanged(listId: StaticListId) {
-    let result = await this.pollListMetadata(undefined, listId);
-
-    while (!this.disposed) {
-      await delay(this.metadataWriteThrottleMs);
-      result = await this.pollListMetadata(result.version, listId);
-      await this.getMetadataTable().put(result.value);
-      this.getMetadataLogger().debug("Wrote metadata to DB for list {listId}", {
-        listId,
-      });
+    for (const context of this.contextByListId.values()) {
+      context.databases.closeAll();
     }
   }
 
@@ -348,84 +336,610 @@ export class StaticListsService {
     return logger.getChild([listId]);
   }
 
-  private getMetadataLogger(): Logger {
-    return logger.getChild([metadataTableName]);
-  }
-
-  private getMetadataTable(): Table<unknown> {
-    return this.db.table<unknown>(metadataTableName);
-  }
-
-  public async pollListMetadata(
-    lastPollVersion: PollVersion | undefined,
+  /**
+   * Initialization is where we reconcile persisted metadata with the actual
+   * databases on disk.
+   *
+   * The recovery policy intentionally treats remote and local state
+   * differently: remote snapshots are disposable and cheap to redownload,
+   * while local rows are the only state that may represent developer edits.
+   * That is why metadata/summary incompatibility resets remote state only, but
+   * a physical storage-version mismatch still wipes everything.
+   */
+  private async initializeListContext(
     listId: StaticListId,
-  ): Promise<PollResult<StaticListMetadata>> {
+  ): Promise<ListContext> {
+    const listLogger = this.getListLogger(listId);
+    const definitionInfo = getStaticListDefinitionInfo(listId);
+    const metadataStore = getStaticListMetadataStore(listId);
+    let databases = new StaticListDatabases(listId);
+
+    async function resetDatabases() {
+      databases.closeAll();
+      await databases.deleteAllDatabases();
+      databases = new StaticListDatabases(listId);
+    }
+
+    async function resetRemoteDatabases() {
+      databases.closeAll();
+      await databases.deleteRemoteDatabases();
+      databases = new StaticListDatabases(listId);
+    }
+
+    const rawMetadata = await metadataStore.getValue();
+    let metadata = rawMetadata
+      ? tryParseStaticListMetadata(listId, rawMetadata)
+      : undefined;
+
+    if (rawMetadata && !metadata) {
+      listLogger.warn(
+        "Stored metadata is incompatible with the current list definition, resetting remote state and preserving local rows",
+      );
+
+      await resetRemoteDatabases();
+      metadata = createDefaultStaticListMetadata(listId);
+      await metadataStore.setValue(metadata);
+    }
+
+    if (
+      metadata &&
+      metadata.physicalStorageVersion !==
+        definitionInfo.definition.physicalStorageVersion
+    ) {
+      listLogger.warn(
+        "Physical storage version mismatch {storedVersion} -> {runtimeVersion}, wiping list storage",
+        {
+          storedVersion: metadata.physicalStorageVersion,
+          runtimeVersion: definitionInfo.definition.physicalStorageVersion,
+        },
+      );
+
+      await resetDatabases();
+      metadata = undefined;
+    }
+
+    if (!metadata) {
+      await resetRemoteDatabases();
+      metadata = createDefaultStaticListMetadata(listId);
+      await metadataStore.setValue(metadata);
+    }
+
+    const activeRemoteRows = await databases.getRemoteRows(
+      metadata.remoteActiveInstance,
+      { createIfMissing: false },
+    );
+    if (metadata.remoteActive && !activeRemoteRows) {
+      listLogger.warn(
+        "Remote active database is missing, clearing remote metadata",
+      );
+
+      metadata = omitRemoteStaging(omitRemoteActive(metadata));
+      await metadataStore.setValue(metadata);
+    }
+
+    const readableMetadata = metadata;
+
+    if (readableMetadata.remoteStaging) {
+      listLogger.warn(
+        "Abandoned remote staging detected, clearing inactive store",
+      );
+
+      await databases.deleteRemoteDatabase(
+        pickAnotherRemoteInstance(readableMetadata.remoteActiveInstance),
+      );
+
+      metadata = omitRemoteStaging(readableMetadata);
+
+      await metadataStore.setValue(metadata);
+    }
+
+    if (metadata.localUpdatedAt) {
+      const localTable = await databases.getLocalRows({
+        createIfMissing: false,
+      });
+      if (!localTable || (await localTable.count()) === 0) {
+        listLogger.warn(
+          "Local database is missing or empty, clearing local metadata",
+        );
+
+        if (localTable) {
+          await databases.deleteLocalDatabase();
+        }
+
+        metadata = omitLocalUpdatedAt(metadata);
+        await metadataStore.setValue(metadata);
+      }
+    }
+
+    if (
+      metadata.derivedDataVersion !==
+        definitionInfo.definition.derivedDataVersion &&
+      !tryExtractSummaryFromMetadata(metadata)
+    ) {
+      listLogger.warn(
+        "Stored active summary is incompatible with derived data version {storedVersion} -> {runtimeVersion}, resetting remote state and preserving local rows",
+        {
+          storedVersion: metadata.derivedDataVersion,
+          runtimeVersion: definitionInfo.definition.derivedDataVersion,
+        },
+      );
+
+      await resetRemoteDatabases();
+      metadata = createDefaultStaticListMetadata(listId);
+      await metadataStore.setValue(metadata);
+    }
+
+    const initializedMetadata = metadata;
+
+    const context: ListContext = {
+      listId,
+      definitionInfo,
+      databases,
+      metadataStore,
+      metadata: initializedMetadata,
+    };
+
+    this.contextByListId.set(listId, context);
+
+    if (shouldComputeDevSummaries(initializedMetadata.combiningMode)) {
+      await this.recomputeDevSummaries(listId);
+    }
+
+    this.publishListState(listId);
+    return context;
+  }
+
+  private async ensureListContext(listId: StaticListId): Promise<ListContext> {
+    const cachedContext = this.contextByListId.get(listId);
+    if (cachedContext) {
+      return cachedContext;
+    }
+
+    let initializationPromise = this.initializationPromiseByListId.get(listId);
+    if (!initializationPromise) {
+      initializationPromise = this.initializeListContext(listId).finally(() => {
+        this.initializationPromiseByListId.delete(listId);
+      });
+
+      this.initializationPromiseByListId.set(listId, initializationPromise);
+    }
+
+    return await initializationPromise;
+  }
+
+  private getCurrentMetadata<ListId extends StaticListId>(
+    listId: ListId,
+  ): StaticListMetadata<ListId> {
+    const context = this.contextByListId.get(listId);
+    if (!context) {
+      // eslint-disable-next-line no-restricted-syntax -- callers only reach this after initialization; throwing surfaces broken service state immediately
+      throw new Error(`Static list context is not initialized for ${listId}`);
+    }
+
+    const { metadata } = context;
+    if (metadata.listId !== listId) {
+      // eslint-disable-next-line no-restricted-syntax -- stored context metadata should always match the owning list id
+      throw new Error(`Static list metadata listId mismatch for ${listId}`);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- runtime guard above re-establishes the generic list-id correlation
+    return metadata as StaticListMetadata<ListId>;
+  }
+
+  private async persistMetadata<ListId extends StaticListId>(
+    listId: ListId,
+    metadata: StaticListMetadata<ListId>,
+    options?: { publish?: boolean },
+  ): Promise<void> {
+    const context = await this.ensureListContext(listId);
+    context.metadata = metadata;
+    await context.metadataStore.setValue(metadata);
+    if (options?.publish !== false) {
+      this.publishListState(listId);
+    }
+  }
+
+  private publishListState(listId: StaticListId): void {
+    const context = this.contextByListId.get(listId);
+    if (!context) {
+      return;
+    }
+
+    const metadata = context.metadata;
+
+    this.pollableListMetadataByListId[listId].setValue(metadata);
+    this.pollableRemoteStagingSummaryByListId[listId].setValue(
+      metadata.remoteStaging
+        ? extractSummaryFromMetadata(metadata, "remoteStaging")
+        : undefined,
+    );
+    this.pollableListUpdatedAtByListId[listId].setValue(
+      extractUpdatedAtFromMetadata(metadata),
+    );
+
+    if (metadata.combiningMode === "remoteOnly") {
+      this.pollableListSummaryByListId[listId].setValue(
+        extractSummaryFromMetadata(metadata),
+      );
+      return;
+    }
+
+    if (metadata.combiningMode === "localOnly") {
+      this.pollableListSummaryByListId[listId].setValue(
+        this.localSummaryByListId.get(listId) ?? createEmptySummary(listId),
+      );
+      return;
+    }
+
+    this.pollableListSummaryByListId[listId].setValue(
+      this.combinedSummaryByListId.get(listId) ?? createEmptySummary(listId),
+    );
+  }
+
+  private async getActiveRemoteTable(
+    listId: StaticListId,
+  ): Promise<Table<StoredRemoteRow, number> | undefined> {
+    const context = await this.ensureListContext(listId);
+    return await context.databases.getRemoteRows(
+      context.metadata.remoteActiveInstance,
+      { createIfMissing: false },
+    );
+  }
+
+  private async getLocalDatabase(
+    listId: StaticListId,
+    options?: { createIfMissing?: boolean },
+  ): Promise<StaticListRowsDatabase<StoredLocalRow, string> | undefined> {
+    const context = await this.ensureListContext(listId);
+    return await context.databases.getLocalDatabase(options);
+  }
+
+  private async getWritableLocalDatabase(
+    listId: StaticListId,
+  ): Promise<StaticListRowsDatabase<StoredLocalRow, string>> {
+    const localDatabase = await this.getLocalDatabase(listId, {
+      createIfMissing: true,
+    });
+
+    if (!localDatabase) {
+      // eslint-disable-next-line no-restricted-syntax -- write callers require a writable local database
+      throw new Error(`Failed to create local database for ${listId}`);
+    }
+
+    return localDatabase;
+  }
+
+  private async getLocalTable(
+    listId: StaticListId,
+    options?: { createIfMissing?: boolean },
+  ): Promise<Table<StoredLocalRow, string> | undefined> {
+    const localDatabase = await this.getLocalDatabase(listId, options);
+    return localDatabase?.rows;
+  }
+
+  private async withLocalMutationLock<T>(
+    listId: StaticListId,
+    callback: () => Promise<T>,
+  ): Promise<T> {
+    const previousTail = this.localMutationTailByListId.get(listId);
+    const settledPreviousTail = previousTail?.catch(() => undefined);
+    let releaseCurrentTail: (() => void) | undefined;
+    const currentTail = new Promise<void>((resolve) => {
+      releaseCurrentTail = resolve;
+    });
+    const queuedTail = (settledPreviousTail ?? Promise.resolve()).then(
+      () => currentTail,
+    );
+
+    this.localMutationTailByListId.set(listId, queuedTail);
+    await settledPreviousTail;
+
+    try {
+      return await callback();
+    } finally {
+      releaseCurrentTail?.();
+
+      if (this.localMutationTailByListId.get(listId) === queuedTail) {
+        this.localMutationTailByListId.delete(listId);
+      }
+    }
+  }
+
+  private async afterLocalRowsChanged(
+    listId: StaticListId,
+    localTable?: Table<StoredLocalRow, string>,
+  ): Promise<void> {
+    const remainingLocalRowCount = localTable ? await localTable.count() : 0;
+    const metadata = this.getCurrentMetadata(listId);
+    const updatedMetadata =
+      remainingLocalRowCount === 0
+        ? omitLocalUpdatedAt(metadata)
+        : {
+            ...metadata,
+            localUpdatedAt: isoDateTimeSchema.parse(Date.now()),
+          };
+
+    if (remainingLocalRowCount === 0) {
+      const context = await this.ensureListContext(listId);
+      await context.databases.deleteLocalDatabase();
+    }
+
+    await this.persistMetadata(listId, updatedMetadata, {
+      publish: !shouldComputeDevSummaries(updatedMetadata.combiningMode),
+    });
+
+    if (shouldComputeDevSummaries(updatedMetadata.combiningMode)) {
+      await this.recomputeDevSummaries(listId);
+      return;
+    }
+
+    this.clearDevSummaryCaches(listId);
+    this.publishListState(listId);
+  }
+
+  private async getPureLocalRows(
+    listId: StaticListId,
+  ): Promise<StoredLocalRow[]> {
+    const localTable = await this.getLocalTable(listId, {
+      createIfMissing: false,
+    });
+    if (!localTable) {
+      return [];
+    }
+
+    const localRows = sortLocalRows(await localTable.toArray());
+    const activeRemoteTable = await this.getActiveRemoteTable(listId);
+    if (!activeRemoteTable) {
+      return localRows;
+    }
+    const remotePresenceByLogicalPrimaryKey = new Map<IDBValidKey, boolean>();
+
+    for (const localRow of localRows) {
+      if (localRow.p === undefined) {
+        continue;
+      }
+
+      if (!remotePresenceByLogicalPrimaryKey.has(localRow.p)) {
+        remotePresenceByLogicalPrimaryKey.set(
+          localRow.p,
+          (await activeRemoteTable
+            .where("p")
+            .equals(toIndexableType(localRow.p))
+            .count()) > 0,
+        );
+      }
+    }
+
+    return localRows.filter(
+      (localRow) =>
+        localRow.p === undefined ||
+        !remotePresenceByLogicalPrimaryKey.get(localRow.p),
+    );
+  }
+
+  private async recomputeLocalSummary(
+    listId: StaticListId,
+  ): Promise<StaticListSummary> {
+    const mutableSummary: WritableDeep<StaticListSummary> =
+      cloneEmptySummary(listId);
+    const localTable = await this.getLocalTable(listId, {
+      createIfMissing: false,
+    });
+    const localRows = localTable ? await localTable.toArray() : [];
+
+    for (const localRow of localRows) {
+      tryInterpretSummaryItemDelta(
+        listId,
+        mutableSummary,
+        localRow,
+        "local",
+        1,
+      );
+    }
+
+    const summary: StaticListSummary = mutableSummary;
+    this.localSummaryByListId.set(listId, summary);
+    return summary;
+  }
+
+  private async recomputeCombinedSummary(
+    listId: StaticListId,
+  ): Promise<StaticListSummary> {
+    const metadata = this.getCurrentMetadata(listId);
+    const mutableSummary: WritableDeep<StaticListSummary> = structuredClone(
+      extractSummaryFromMetadata(metadata),
+    );
+    const localTable = await this.getLocalTable(listId, {
+      createIfMissing: false,
+    });
+    const localRows = localTable ? await localTable.toArray() : [];
+    const activeRemoteTable = await this.getActiveRemoteTable(listId);
+    if (!activeRemoteTable) {
+      for (const localRow of localRows) {
+        tryInterpretSummaryItemDelta(
+          listId,
+          mutableSummary,
+          localRow,
+          "local",
+          1,
+        );
+      }
+
+      const summary: StaticListSummary = mutableSummary;
+      this.combinedSummaryByListId.set(listId, summary);
+      return summary;
+    }
+    const processedShadowedKeys = new Set<IDBValidKey>();
+
+    for (const localRow of localRows) {
+      if (localRow.p !== undefined && !processedShadowedKeys.has(localRow.p)) {
+        const matchingRemoteRows = await activeRemoteTable
+          .where("p")
+          .equals(toIndexableType(localRow.p))
+          .toArray();
+
+        for (const remoteRow of matchingRemoteRows) {
+          tryInterpretSummaryItemDelta(
+            listId,
+            mutableSummary,
+            remoteRow,
+            "remote",
+            -1,
+          );
+        }
+
+        processedShadowedKeys.add(localRow.p);
+      }
+
+      tryInterpretSummaryItemDelta(
+        listId,
+        mutableSummary,
+        localRow,
+        "local",
+        1,
+      );
+    }
+
+    const summary: StaticListSummary = mutableSummary;
+    this.combinedSummaryByListId.set(listId, summary);
+    return summary;
+  }
+
+  private async recomputeDevSummaries(listId: StaticListId): Promise<void> {
+    const metadata = this.getCurrentMetadata(listId);
+    const localSummary = await this.recomputeLocalSummary(listId);
+
+    if (metadata.combiningMode === "remoteWithLocalOverrides") {
+      await this.recomputeCombinedSummary(listId);
+    } else if (metadata.combiningMode === "localOnly") {
+      this.combinedSummaryByListId.set(listId, localSummary);
+    }
+
+    this.publishListState(listId);
+  }
+
+  private clearDevSummaryCaches(listId: StaticListId): void {
+    this.localSummaryByListId.delete(listId);
+    this.combinedSummaryByListId.delete(listId);
+  }
+
+  private resolveSlotName(
+    listId: StaticListId,
+    publicIndexName: string,
+  ): "p" | `s${number}` {
+    const slotName =
+      getStaticListDefinitionInfo(listId).publicIndexNameToSlotName[
+        publicIndexName
+      ];
+
+    if (!slotName) {
+      // eslint-disable-next-line no-restricted-syntax -- callers must request declared indexes only
+      throw new Error(
+        `Unknown static list index "${publicIndexName}" for ${listId}`,
+      );
+    }
+
+    return slotName;
+  }
+
+  private async findRowInTable<
+    Row extends StoredRemoteRow | StoredLocalRow,
+    Key,
+  >(
+    table: Table<Row, Key>,
+    slotName: "p" | `s${number}`,
+    value: IDBValidKey,
+  ): Promise<Row | undefined> {
+    return (
+      (await table.where(slotName).equals(toIndexableType(value)).first()) ??
+      undefined
+    );
+  }
+
+  private async getVisibleEntryCount(listId: StaticListId): Promise<number> {
+    const metadata = await this.getListMetadata(listId);
+
+    if (metadata.combiningMode === "localOnly") {
+      const localTable = await this.getLocalTable(listId, {
+        createIfMissing: false,
+      });
+      return localTable ? await localTable.count() : 0;
+    }
+
+    const activeRemoteTable = await this.getActiveRemoteTable(listId);
+    const remoteStoredCount = activeRemoteTable
+      ? await activeRemoteTable.count()
+      : 0;
+    if (metadata.combiningMode === "remoteOnly") {
+      return remoteStoredCount;
+    }
+
+    const pureLocalRows = await this.getPureLocalRows(listId);
+    return remoteStoredCount + pureLocalRows.length;
+  }
+
+  public async pollListMetadata<ListId extends StaticListId>(
+    lastPollVersion: PollVersion | undefined,
+    listId: ListId,
+  ): Promise<PollResult<StaticListMetadata<ListId>>> {
+    await this.ensureListContext(listId);
+
     let result:
-      | PollResult<StaticListMetadata>
+      | PollResult<StaticListMetadata | undefined>
       | PollResult<undefined>
       | undefined;
 
     do {
-      result = await this.pollableListMetadataByListId[listId].poll(
-        lastPollVersion ?? result?.version,
-      );
-    } while (!result?.value);
+      const pollVersion =
+        result === undefined ? lastPollVersion : result.version;
+      result =
+        await this.pollableListMetadataByListId[listId].poll(pollVersion);
+    } while (!result.value);
 
-    return result;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- pollable values are published from validated per-list metadata
+    return result as unknown as PollResult<StaticListMetadata<ListId>>;
   }
 
-  public async getListMetadata(
-    listId: StaticListId,
-  ): Promise<StaticListMetadata> {
+  public async getListMetadata<ListId extends StaticListId>(
+    listId: ListId,
+  ): Promise<StaticListMetadata<ListId>> {
     const result = await this.pollListMetadata(undefined, listId);
     return result.value;
   }
 
-  private setListMetadata(metadata: StaticListMetadata): void {
-    this.activeRemoteTableCache.delete(metadata.listId);
-    this.pollableListMetadataByListId[metadata.listId].setValue(metadata);
-    this.pollableListSummaryByListId[metadata.listId].setValue(
-      extractCombinedSummaryFromMetadata(metadata),
-    );
-    this.pollableRemoteNextListSummaryByListId[metadata.listId].setValue(
-      extractSummaryFromMetadata(metadata, "remoteNext"),
-    );
-    this.pollableListUpdatedAtByListId[metadata.listId].setValue(
-      extractUpdatedAtFromMetadata(metadata),
-    );
-  }
-
-  // Combined summary (respects combining mode) — used by most consumers
-  public async pollListSummary(
+  public async pollListSummary<ListId extends StaticListId>(
     lastPollVersion: PollVersion | undefined,
-    listId: StaticListId,
-  ): Promise<PollResult<StaticListSummary>> {
+    listId: ListId,
+  ): Promise<PollResult<StaticListSummary<ListId>>> {
+    await this.ensureListContext(listId);
+
     let result:
-      | PollResult<StaticListSummary>
+      | PollResult<StaticListSummary | undefined>
       | PollResult<undefined>
       | undefined;
 
     do {
-      result = await this.pollableListSummaryByListId[listId].poll(
-        lastPollVersion ?? result?.version,
-      );
-    } while (!result?.value);
+      const pollVersion =
+        result === undefined ? lastPollVersion : result.version;
+      result = await this.pollableListSummaryByListId[listId].poll(pollVersion);
+    } while (!result.value);
 
-    return result;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- pollable values are published from list-specific validated summaries
+    return result as unknown as PollResult<StaticListSummary<ListId>>;
   }
 
-  public async getListSummary(
-    listId: StaticListId,
-  ): Promise<StaticListSummary> {
+  public async getListSummary<ListId extends StaticListId>(
+    listId: ListId,
+  ): Promise<StaticListSummary<ListId>> {
     const result = await this.pollListSummary(undefined, listId);
     return result.value;
   }
 
-  // Combined list updated timestamp (respects combining mode)
   public async pollListUpdatedAt(
     lastPollVersion: PollVersion | undefined,
     listId: StaticListId,
   ): Promise<PollResult<IsoDateTime | undefined>> {
+    await this.ensureListContext(listId);
     return this.pollableListUpdatedAtByListId[listId].poll(lastPollVersion);
   }
 
@@ -436,162 +950,166 @@ export class StaticListsService {
     return result.value;
   }
 
-  // Remote summary (always from remote, regardless of combining mode)
-  public async getRemoteListSummary(
-    listId: StaticListId,
-  ): Promise<StaticListSummary> {
+  public async getRemoteListSummary<ListId extends StaticListId>(
+    listId: ListId,
+  ): Promise<StaticListSummary<ListId>> {
     const metadata = await this.getListMetadata(listId);
     return extractSummaryFromMetadata(metadata);
   }
 
-  // Local summary
-  public async getLocalListSummary(
-    listId: StaticListId,
-  ): Promise<StaticListSummary> {
+  public async getRemoteStagingSummary<ListId extends StaticListId>(
+    listId: ListId,
+  ): Promise<StaticListSummary<ListId> | undefined> {
     const metadata = await this.getListMetadata(listId);
-    return extractLocalSummaryFromMetadata(metadata);
+    return metadata.remoteStaging
+      ? extractSummaryFromMetadata(metadata, "remoteStaging")
+      : undefined;
   }
 
-  public async pollRemoteNextListSummary(
+  public async pollRemoteStagingSummary<ListId extends StaticListId>(
     lastPollVersion: PollVersion | undefined,
-    listId: StaticListId,
-  ): Promise<PollResult<StaticListSummary>> {
-    let result:
-      | PollResult<StaticListSummary>
-      | PollResult<undefined>
-      | undefined;
-
-    do {
-      result = await this.pollableRemoteNextListSummaryByListId[listId].poll(
-        lastPollVersion ?? result?.version,
+    listId: ListId,
+  ): Promise<PollResult<StaticListSummary<ListId> | undefined>> {
+    await this.ensureListContext(listId);
+    const result =
+      await this.pollableRemoteStagingSummaryByListId[listId].poll(
+        lastPollVersion,
       );
-    } while (!result?.value);
-    return result;
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- pollable values are published from list-specific validated summaries
+    return result as unknown as PollResult<
+      StaticListSummary<ListId> | undefined
+    >;
   }
 
-  public async getRemoteNextListSummary(
-    listId: StaticListId,
-  ): Promise<StaticListSummary> {
-    const result = await this.pollRemoteNextListSummary(undefined, listId);
-    return result.value;
-  }
-
-  private async waitForAnotherLock(
-    listId: StaticListId,
-    initialListMetadata: StaticListMetadata,
-  ): Promise<StaticListMetadata> {
-    let lockMetadata = initialListMetadata;
-
-    if (!lockMetadata.remoteNext) {
-      return lockMetadata;
+  public async getLocalListSummary<ListId extends StaticListId>(
+    listId: ListId,
+  ): Promise<StaticListSummary<ListId>> {
+    if (!this.localSummaryByListId.has(listId)) {
+      await this.recomputeLocalSummary(listId);
     }
 
-    const listLogger = this.getListLogger(listId);
-    listLogger.debug("Waiting for another lock");
-
-    do {
-      const lockReportedAtTimestamp = new Date(
-        lockMetadata.remoteNext.updatedAt,
-      ).getTime();
-
-      if (lockReportedAtTimestamp < Date.now() - lockTimeoutInMs) {
-        listLogger.debug(
-          "Another lock has been held for over {lockTimeoutInMs}ms, overtaking it",
-          { lockTimeoutInMs },
-        );
-
-        return lockMetadata;
-      }
-
-      await delay(lockIntervalInMs);
-      lockMetadata = await this.getListMetadata(listId);
-    } while (lockMetadata.remoteNext);
-
-    listLogger.debug("Another lock is no longer held");
-    return lockMetadata;
+    return (
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- local summaries are stored per validated list id but the map itself is intentionally erased
+      (this.localSummaryByListId.get(listId) as
+        | StaticListSummary<ListId>
+        | undefined) ?? createEmptySummary(listId)
+    );
   }
 
-  private isListUpToDate(
-    listMetadata: StaticListMetadata,
-    upstreamGeneratedAt: IsoDateTime,
-    toleranceInMinutes: number | undefined,
-  ): boolean {
-    const activeStartedAtLocally = listMetadata.remoteActive?.startedAt;
-    if (!activeStartedAtLocally) {
-      return false;
+  public getLocalRowLimit(listId: StaticListId): number {
+    return (
+      staticListDefinitionLookup[listId].localRowLimit ?? defaultLocalRowLimit
+    );
+  }
+
+  public async getCombiningMode(
+    listId: StaticListId,
+  ): Promise<StaticListCombiningMode> {
+    const metadata = await this.getListMetadata(listId);
+    return metadata.combiningMode;
+  }
+
+  public async setCombiningMode(
+    listId: StaticListId,
+    mode: StaticListCombiningMode,
+  ): Promise<void> {
+    const metadata = await this.getListMetadata(listId);
+    const updatedMetadata = { ...metadata, combiningMode: mode };
+
+    await this.persistMetadata(listId, updatedMetadata, {
+      publish: !shouldComputeDevSummaries(mode),
+    });
+
+    if (shouldComputeDevSummaries(mode)) {
+      await this.recomputeDevSummaries(listId);
+      return;
     }
 
-    if (activeStartedAtLocally >= upstreamGeneratedAt) {
+    this.clearDevSummaryCaches(listId);
+    this.publishListState(listId);
+  }
+
+  private needsRemoteUpdate({
+    metadata,
+    upstreamGeneratedAt,
+    toleranceInMinutes,
+    listId,
+  }: {
+    metadata: StaticListMetadata;
+    upstreamGeneratedAt: IsoDateTime;
+    toleranceInMinutes: number | undefined;
+    listId: StaticListId;
+  }): boolean {
+    const definition = staticListDefinitionLookup[listId];
+
+    if (!metadata.remoteActive) {
       return true;
+    }
+
+    if (metadata.derivedDataVersion !== definition.derivedDataVersion) {
+      return true;
+    }
+
+    if (metadata.remoteActive.upstreamInfo.generatedAt >= upstreamGeneratedAt) {
+      return false;
     }
 
     return (
       new Date(upstreamGeneratedAt).getTime() +
-        (toleranceInMinutes ?? 0) * 60 * 1000 >=
+        (toleranceInMinutes ?? 0) * 60 * 1000 <
       Date.now()
     );
   }
 
-  public async populateListIfOutdated(
+  private async populateListIfOutdatedInternal(
     listId: StaticListId,
     toleranceInMinutes: number | undefined,
   ): Promise<PopulateFromUrlIfOutdatedResult> {
     const listLogger = this.getListLogger(listId);
-    listLogger.info("Populating if outdated");
-    const startedAt = Date.now();
-
-    const lockId = nanoid(8);
-
+    const context = await this.ensureListContext(listId);
     const rootConfig = await this.rootConfigService.get();
     const upstreamInfo =
       rootConfig.remoteSystemLookup.staticApi.listLookup[listId];
 
+    if (
+      !this.needsRemoteUpdate({
+        listId,
+        metadata: context.metadata,
+        toleranceInMinutes,
+        upstreamGeneratedAt: upstreamInfo.generatedAt,
+      })
+    ) {
+      return { success: true, data: "updateNotNeeded" };
+    }
+
+    const startedAt = Date.now();
+    const startedAtIso = isoDateTimeSchema.parse(startedAt);
+    const targetInstance = pickAnotherRemoteInstance(
+      context.metadata.remoteActiveInstance,
+    );
+    const activeInstance = context.metadata.remoteActiveInstance;
+    const targetDatabase =
+      await context.databases.resetRemoteDatabase(targetInstance);
+    const targetTable = targetDatabase.rows;
+    const mutableStagingSummary: WritableDeep<StaticListSummary> =
+      cloneEmptySummary(listId);
+
+    await this.persistMetadata(
+      listId,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
+      {
+        ...context.metadata,
+        remoteStaging: {
+          startedAt: startedAtIso,
+          updatedAt: startedAtIso,
+          upstreamInfo,
+          summary: structuredClone(mutableStagingSummary),
+        },
+      } as StaticListMetadata,
+    );
+
     try {
-      const initialMetadata = await this.getListMetadata(listId);
-      if (
-        this.isListUpToDate(
-          initialMetadata,
-          upstreamInfo.generatedAt,
-          toleranceInMinutes,
-        )
-      ) {
-        listLogger.info("List is up to date");
-        return { success: true, data: "updateNotNeeded" };
-      }
-
-      const listDefinition: StaticListDefinition =
-        staticListDefinitionLookup[listId];
-
-      const mutableSummary = listDefinition.createEmptySummary();
-
-      let lockMetadata = initialMetadata;
-      do {
-        lockMetadata = await this.waitForAnotherLock(listId, lockMetadata);
-
-        if (
-          this.isListUpToDate(
-            lockMetadata,
-            upstreamInfo.generatedAt,
-            toleranceInMinutes,
-          )
-        ) {
-          return { success: true, data: "updateNotNeeded" };
-        }
-
-        this.setListMetadata({
-          ...lockMetadata,
-          remoteNext: {
-            lockId,
-            startedAt: isoDateTimeSchema.parse(startedAt),
-            summary: structuredClone(mutableSummary),
-            updatedAt: isoDateTimeSchema.parse(startedAt),
-            upstreamInfo,
-          },
-        });
-
-        lockMetadata = await this.getListMetadata(listId);
-      } while (lockMetadata.remoteNext?.lockId !== lockId);
-
       const fetchResult = await fetchFromRemoteSystem({
         aliasManager: this.aliasManagerForStaticApi,
         urlSuffix: `/lists/${listId}.jsonl`,
@@ -615,207 +1133,140 @@ export class StaticListsService {
         return { success: false, error: "No response body from static API" };
       }
 
-      const previouslyActiveStoreName = generateRemoteTableName(
-        listId,
-        initialMetadata.remoteActiveInstance,
-      );
-
-      const previouslyActiveTable = this.db.table<unknown>(
-        previouslyActiveStoreName,
-      );
-
-      const nextInstance = pickAnotherInstance(
-        initialMetadata.remoteActiveInstance,
-      );
-      const nextStoreName = generateRemoteTableName(listId, nextInstance);
-      const nextTable = this.db.table<unknown>(nextStoreName);
-      await nextTable.clear();
-
+      let lineNumber = 0;
       let storedBatchCount = 0;
-      let storedItemCount = 0;
+      let storedRowCount = 0;
+      let rowsToStore: StoredRemoteRow[] = [];
 
-      const storeBatch = async ({
-        items,
-        shouldSetListMetadata,
-      }: {
-        items: unknown[];
-        shouldSetListMetadata: boolean;
-      }): Promise<
-        (PopulateFromUrlIfOutdatedResult & { success: false }) | undefined
-      > => {
-        if (items.length === 0) {
-          return undefined;
+      const flushBatch = async (shouldPersistStagingProgress: boolean) => {
+        if (rowsToStore.length === 0) {
+          return;
         }
 
         storedBatchCount += 1;
-        storedItemCount += items.length;
-        const batchStartedAt = Date.now();
+        storedRowCount += rowsToStore.length;
+        await targetTable.bulkPut(rowsToStore);
+        rowsToStore = [];
 
-        lockMetadata = await this.getListMetadata(listId);
-        const lockMetadataRemoteNext = lockMetadata.remoteNext;
-
-        if (lockMetadataRemoteNext?.lockId !== lockId) {
-          listLogger.error(
-            "List was unexpectedly locked by another instance ({lockId})",
-            { lockId: lockMetadata.remoteNext?.lockId },
-          );
-
-          return {
-            success: false,
-            error: `List was unexpectedly locked by another instance (${lockMetadata.remoteNext?.lockId ?? "unknown"})`,
-          };
+        if (!shouldPersistStagingProgress) {
+          return;
         }
 
-        await this.db.transaction("rw", nextTable, async () => {
-          await nextTable.bulkAdd(items);
-        });
-
-        if (shouldSetListMetadata) {
-          this.setListMetadata({
-            ...lockMetadata,
-            remoteNext: {
-              ...lockMetadataRemoteNext,
-              summary: structuredClone(mutableSummary),
-              updatedAt: isoDateTimeSchema.parse(undefined),
-            },
-          });
+        const currentMetadata = this.getCurrentMetadata(listId);
+        if (!currentMetadata.remoteStaging) {
+          return;
         }
 
-        listLogger.debug(
-          "Stored batch {batchCount} with {length} items in {ms}ms",
+        await this.persistMetadata(
+          listId,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
           {
-            batchCount: storedBatchCount,
-            length: items.length,
-            ms: Date.now() - batchStartedAt,
-          },
+            ...currentMetadata,
+            remoteStaging: {
+              ...currentMetadata.remoteStaging,
+              updatedAt: isoDateTimeSchema.parse(Date.now()),
+              summary: structuredClone(mutableStagingSummary),
+            },
+          } as StaticListMetadata,
         );
-
-        return undefined;
       };
-
-      let lineNumber = 0;
-      let itemsToStore: unknown[] = [];
 
       for await (const line of streamLines(fetchResult.response.body)) {
         lineNumber += 1;
-        const receivedItemResult = listDefinition.receivedItemSchema.safeParse(
-          JSON.parse(line),
-        );
+        const storedRow = createStoredRemoteRow({
+          listId,
+          lineNumber,
+          sourceText: line,
+        });
 
-        if (!receivedItemResult.success) {
-          listLogger.error(
-            "Invalid item received at line {lineNumber}: {line} -> {error}",
-            {
-              lineNumber,
-              line,
-              error: receivedItemResult.error.message,
-            },
+        rowsToStore.push(storedRow);
+
+        const interpretedRow = interpretStoredRow(listId, storedRow, "remote");
+        if (interpretedRow.interpretation.success) {
+          context.definitionInfo.definition.adjustSummary(
+            mutableStagingSummary,
+            interpretedRow.interpretation.item,
+            1,
           );
-          continue;
         }
 
-        const itemToStore = listDefinition.mapReceivedToStored(
-          receivedItemResult.data,
-        );
-
-        itemsToStore.push(itemToStore);
-        listDefinition.mutateSummary(mutableSummary, itemToStore);
-
-        if (itemsToStore.length >= itemBatchSize) {
-          const batchResult = await storeBatch({
-            items: itemsToStore,
-            shouldSetListMetadata: true,
-          });
-          if (batchResult) {
-            return batchResult;
-          }
-          itemsToStore = [];
+        if (rowsToStore.length >= itemBatchSize) {
+          await flushBatch(true);
         }
       }
 
-      const finalBatchResult = await storeBatch({
-        items: itemsToStore,
-        shouldSetListMetadata: false,
-      });
+      await flushBatch(false);
 
-      if (finalBatchResult) {
-        return finalBatchResult;
+      const finishedAtIso = isoDateTimeSchema.parse(Date.now());
+      const finalMetadata = withUpdatedDerivedDataVersion(
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
+        {
+          ...this.getCurrentMetadata(listId),
+          remoteActiveInstance: targetInstance,
+          remoteActive: {
+            startedAt: startedAtIso,
+            updatedAt: finishedAtIso,
+            upstreamInfo,
+            summary: structuredClone(mutableStagingSummary),
+          },
+        } as StaticListMetadata,
+      );
+
+      if (shouldComputeDevSummaries(finalMetadata.combiningMode)) {
+        await this.persistMetadata(listId, omitRemoteStaging(finalMetadata), {
+          publish: false,
+        });
+        await this.recomputeDevSummaries(listId);
+      } else {
+        await this.persistMetadata(listId, omitRemoteStaging(finalMetadata));
       }
 
-      const finalSummary = structuredClone(mutableSummary);
+      await context.databases.deleteRemoteDatabase(activeInstance);
 
       listLogger.info(
-        "Populated {storedItemCount} items (batches: {storedBatchCount}) in {ms}ms with {summary}",
+        "Populated {storedRowCount} remote rows (batches: {storedBatchCount})",
         {
-          storedItemCount,
           storedBatchCount,
-          ms: Date.now() - startedAt,
-          summary: finalSummary,
+          storedRowCount,
         },
       );
-
-      const { remoteNext: unusedRemoteNext, ...metadataWithoutRemoteNext } =
-        lockMetadata;
-      const newMetadata: StaticListMetadata = {
-        ...metadataWithoutRemoteNext,
-        remoteActiveInstance: nextInstance,
-        remoteActive: {
-          startedAt: isoDateTimeSchema.parse(startedAt),
-          summary: finalSummary,
-          updatedAt: isoDateTimeSchema.parse(startedAt),
-          upstreamInfo,
-        },
-      };
-
-      // Recompute combined summary after remote data changed
-      const updatedMetadata = await this.recomputeCombinedSummaryForMetadata(
-        listId,
-        newMetadata,
-      );
-      this.setListMetadata(updatedMetadata);
-
-      listLogger.debug("Saved metadata");
-
-      const clearStartedAt = Date.now();
-      await previouslyActiveTable.clear();
-      listLogger.info("Cleared previously active table in {ms}ms", {
-        ms: Date.now() - clearStartedAt,
-      });
 
       return { success: true, data: "updated" };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      await context.databases.deleteRemoteDatabase(targetInstance);
 
-      listLogger.error(
-        "Unexpected error while populating: {error} {errorStack}",
-        {
-          listId,
-          error: errorMessage,
-          errorStack: error instanceof Error ? error.stack : undefined,
-        },
-      );
-
-      try {
-        const metadata = await this.getListMetadata(listId);
-        if (metadata.remoteNext?.lockId === lockId) {
-          const { remoteNext, ...rest } = metadata;
-          this.setListMetadata(rest);
-        }
-      } catch (anotherError) {
-        const anotherErrorMessage =
-          anotherError instanceof Error
-            ? anotherError.message
-            : String(anotherError);
-
-        logger.error(
-          "Unexpected error while cleaning up after failed populate of list {listId}: {error}",
-          { listId, error: anotherErrorMessage },
-        );
+      const metadata = this.getCurrentMetadata(listId);
+      if (metadata.remoteStaging) {
+        await this.persistMetadata(listId, omitRemoteStaging(metadata));
       }
+
+      const errorMessage = getErrorMessage(error);
+      listLogger.error("Unexpected error while populating: {error}", {
+        error: errorMessage,
+      });
 
       return { success: false, error: errorMessage };
     }
+  }
+
+  public async populateListIfOutdated(
+    listId: StaticListId,
+    toleranceInMinutes: number | undefined,
+  ): Promise<PopulateFromUrlIfOutdatedResult> {
+    const existingPromise = this.updatePromiseByListId.get(listId);
+    if (existingPromise) {
+      return await existingPromise;
+    }
+
+    const updatePromise = this.populateListIfOutdatedInternal(
+      listId,
+      toleranceInMinutes,
+    ).finally(() => {
+      this.updatePromiseByListId.delete(listId);
+    });
+
+    this.updatePromiseByListId.set(listId, updatePromise);
+    return await updatePromise;
   }
 
   public updateIfNeeded(payload?: {
@@ -823,190 +1274,504 @@ export class StaticListsService {
     toleranceInMinutes?: number | undefined;
   }): void {
     for (const listId of payload?.listIds ?? staticListIds) {
-      void this.populateListIfOutdated(listId, payload?.toleranceInMinutes);
-    }
-  }
-
-  // ── Remote table access ────────────────────────────────────────────
-
-  private activeRemoteTableCache = new Map<StaticListId, Table<unknown>>();
-
-  private async getActiveRemoteTable(
-    listId: StaticListId,
-  ): Promise<Table<unknown>> {
-    const cachedResult = this.activeRemoteTableCache.get(listId);
-    if (cachedResult) {
-      return cachedResult;
-    }
-
-    const metadata = await this.getListMetadata(listId);
-    const activeTable = this.db.table<unknown>(
-      generateRemoteTableName(listId, metadata.remoteActiveInstance),
-    );
-    this.activeRemoteTableCache.set(listId, activeTable);
-    return activeTable;
-  }
-
-  // ── Local table access ─────────────────────────────────────────────
-
-  private getLocalTable(listId: StaticListId): Table<unknown> {
-    return this.db.table<unknown>(generateLocalTableName(listId));
-  }
-
-  // ── Combining mode ─────────────────────────────────────────────────
-
-  public async getCombiningMode(
-    listId: StaticListId,
-  ): Promise<StaticListCombiningMode> {
-    const metadata = await this.getListMetadata(listId);
-    return metadata.combiningMode;
-  }
-
-  public async setCombiningMode(
-    listId: StaticListId,
-    mode: StaticListCombiningMode,
-  ): Promise<void> {
-    const metadata = await this.getListMetadata(listId);
-    const updatedMetadata = await this.recomputeCombinedSummaryForMetadata(
-      listId,
-      { ...metadata, combiningMode: mode },
-    );
-    this.setListMetadata(updatedMetadata);
-  }
-
-  // ── Local item management ──────────────────────────────────────────
-
-  public async getLocalItems<ListId extends StaticListId>(
-    listId: ListId,
-  ): Promise<Array<StaticListItem<ListId>>> {
-    const localTable = this.getLocalTable(listId);
-
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- data type is unknown, but we've parsed it with the right schema
-    return (await localTable.toArray()) as Array<StaticListItem<ListId>>;
-  }
-
-  public async setLocalItems<ListId extends StaticListId>(
-    listId: ListId,
-    items: Array<StaticListItem<ListId>>,
-  ): Promise<void> {
-    const localTable = this.getLocalTable(listId);
-    await localTable.clear();
-    if (items.length > 0) {
-      await localTable.bulkAdd(items);
-    }
-    await this.recomputeLocalAndCombinedSummary(listId);
-  }
-
-  public async addLocalItem<ListId extends StaticListId>(
-    listId: ListId,
-    item: StaticListItem<ListId>,
-  ): Promise<void> {
-    const localTable = this.getLocalTable(listId);
-    await localTable.add(item);
-    await this.recomputeLocalAndCombinedSummary(listId);
-  }
-
-  public async putLocalItem<ListId extends StaticListId>(
-    listId: ListId,
-    item: StaticListItem<ListId>,
-  ): Promise<void> {
-    const listDefinition = staticListDefinitionLookup[listId];
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- indexes are always strings (object keys)
-    const firstIndex = listDefinition.indexes[0] as string;
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-    const firstIndexValue = (item as Record<string, unknown>)[firstIndex];
-
-    const localTable = this.getLocalTable(listId);
-    await localTable.where({ [firstIndex]: firstIndexValue }).delete();
-    await localTable.add(item);
-    await this.recomputeLocalAndCombinedSummary(listId);
-  }
-
-  public async removeLocalItem<
-    ListId extends StaticListId,
-    Index extends keyof z.infer<
-      (typeof staticListDefinitionLookup)[ListId]["storedItemSchema"]
-    >,
-  >(
-    listId: ListId,
-    index: Index,
-    value: z.infer<
-      (typeof staticListDefinitionLookup)[ListId]["storedItemSchema"]
-    >[Index],
-  ): Promise<{ deletedCount: number }> {
-    const localTable = this.getLocalTable(listId);
-    const deletedCount = await localTable
-      .where({ [String(index)]: value })
-      .delete();
-    await this.recomputeLocalAndCombinedSummary(listId);
-    return { deletedCount };
-  }
-
-  // ── Item origin ────────────────────────────────────────────────────
-
-  public async getItemOrigin<
-    ListId extends StaticListId,
-    Index extends keyof z.infer<
-      (typeof staticListDefinitionLookup)[ListId]["storedItemSchema"]
-    >,
-  >(
-    listId: ListId,
-    index: Index,
-    value: z.infer<
-      (typeof staticListDefinitionLookup)[ListId]["storedItemSchema"]
-    >[Index],
-  ): Promise<StaticListItemOrigin | undefined> {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- indexes are always strings (object keys)
-    const firstIndex = staticListDefinitionLookup[listId].indexes[0] as string;
-    const localTable = this.getLocalTable(listId);
-    const remoteTable = await this.getActiveRemoteTable(listId);
-
-    // Look up by the provided index to find items
-    const localItem = await localTable.get({ [index]: value });
-    const remoteItem = await remoteTable.get({ [index]: value });
-
-    if (localItem && remoteItem) {
-      // Check if the local item matches a remote item by first index (override)
-      const localFirstIndexValue =
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-        (localItem as Record<string, unknown>)[firstIndex];
-      const remoteByFirstIndex = await remoteTable.get({
-        [firstIndex]: localFirstIndexValue,
+      void this.populateListIfOutdated(
+        listId,
+        payload?.toleranceInMinutes,
+      ).catch((error: unknown) => {
+        this.getListLogger(listId).error(
+          "Unexpected error while updating static list: {error}",
+          {
+            error: getErrorMessage(error),
+          },
+        );
       });
-      return remoteByFirstIndex ? "localOverride" : "local";
     }
-
-    if (localItem) {
-      return "local";
-    }
-
-    if (remoteItem) {
-      return "remote";
-    }
-
-    return undefined;
   }
 
-  // ── Paginated read access ─────────────────────────────────────────
+  private prepareLocalRow(
+    listId: StaticListId,
+    item: unknown,
+    options?: StaticListPutLocalItemsOptions,
+    existingRowId?: string,
+  ): PreparedLocalRowResult {
+    const updatedAt = Date.now();
+    const validate = options?.validate ?? true;
 
-  public async getItemCount(listId: StaticListId): Promise<number> {
+    if (validate) {
+      const result = prepareValidatedLocalRow({
+        listId,
+        item,
+        existingRowId,
+        updatedAt,
+      });
+
+      if (!result.success) {
+        return {
+          success: false,
+          error: result.error,
+          details: result.details,
+        };
+      }
+
+      return { success: true, row: result.row };
+    }
+
+    const result = prepareUnvalidatedLocalRow({
+      listId,
+      item,
+      existingRowId,
+      updatedAt,
+    });
+
+    if (!result.success) {
+      return result;
+    }
+
+    return { success: true, row: result.row };
+  }
+
+  private checkPutLocalRowLimit(
+    listId: StaticListId,
+    existingRows: StoredLocalRow[],
+    rows: StoredLocalRow[],
+  ): LocalWriteResult {
+    const limit = this.getLocalRowLimit(listId);
+    const existingLogicalPrimaryKeys = new Set(
+      existingRows.flatMap((row) => (row.p === undefined ? [] : [row.p])),
+    );
+
+    const distinctNewLogicalPrimaryKeys = new Set<IDBValidKey>();
+    let rowsWithoutLogicalPrimaryKey = 0;
+
+    for (const row of rows) {
+      if (row.p === undefined) {
+        rowsWithoutLogicalPrimaryKey += 1;
+        continue;
+      }
+
+      distinctNewLogicalPrimaryKeys.add(row.p);
+    }
+
+    let finalCount = existingRows.length + rowsWithoutLogicalPrimaryKey;
+
+    for (const logicalPrimaryKey of distinctNewLogicalPrimaryKeys) {
+      if (!existingLogicalPrimaryKeys.has(logicalPrimaryKey)) {
+        finalCount += 1;
+      }
+    }
+
+    if (finalCount > limit) {
+      return {
+        success: false,
+        error: "localRowLimitExceeded",
+        limit,
+        attempting: finalCount,
+      };
+    }
+
+    return { success: true };
+  }
+
+  public async putLocalItem(
+    listId: StaticListId,
+    item: unknown,
+    options?: StaticListPutLocalItemsOptions,
+  ): Promise<LocalWriteResult> {
+    return await this.putLocalItems(listId, [item], options);
+  }
+
+  public async putLocalItems(
+    listId: StaticListId,
+    items: unknown[],
+    options?: StaticListPutLocalItemsOptions,
+  ): Promise<LocalWriteResult> {
+    return await this.withLocalMutationLock(listId, async () => {
+      const existingLocalTable = await this.getLocalTable(listId, {
+        createIfMissing: false,
+      });
+      const existingRows = existingLocalTable
+        ? await existingLocalTable.toArray()
+        : [];
+      const exactTargetRow =
+        options?.rowKey && items.length === 1
+          ? existingRows.find((existingRow) => existingRow.i === options.rowKey)
+          : undefined;
+      const existingRowByLogicalPrimaryKey = new Map<
+        IDBValidKey,
+        StoredLocalRow
+      >();
+
+      for (const existingRow of existingRows) {
+        if (
+          existingRow.p !== undefined &&
+          !existingRowByLogicalPrimaryKey.has(existingRow.p)
+        ) {
+          existingRowByLogicalPrimaryKey.set(existingRow.p, existingRow);
+        }
+      }
+
+      if (options?.rowKey && items.length === 1) {
+        if (!exactTargetRow) {
+          return {
+            success: false,
+            error: "localRowNotFound",
+          };
+        }
+
+        const preparedRowResult = this.prepareLocalRow(
+          listId,
+          items[0],
+          options,
+          exactTargetRow.i,
+        );
+        if (!preparedRowResult.success) {
+          return preparedRowResult;
+        }
+
+        const existingRowsWithoutTarget = existingRows.filter(
+          (existingRow) => existingRow.i !== exactTargetRow.i,
+        );
+        const limitCheckResult = this.checkPutLocalRowLimit(
+          listId,
+          existingRowsWithoutTarget,
+          [preparedRowResult.row],
+        );
+        if (!limitCheckResult.success) {
+          return limitCheckResult;
+        }
+
+        const localDatabase = await this.getWritableLocalDatabase(listId);
+        const localTable = localDatabase.rows;
+        await localDatabase.db.transaction("rw", localTable, async () => {
+          // A concrete row edit should keep controlling that physical row even
+          // if the user changes its logical key. If the new key collides with
+          // another local row, we prefer one deterministic winner over silently
+          // leaving duplicate local rows around.
+          if (preparedRowResult.row.p !== undefined) {
+            const conflictingRowIds = existingRowsWithoutTarget.flatMap(
+              (existingRow) =>
+                existingRow.p === preparedRowResult.row.p
+                  ? [existingRow.i]
+                  : [],
+            );
+
+            if (conflictingRowIds.length > 0) {
+              await localTable.bulkDelete(conflictingRowIds);
+            }
+          }
+
+          await localTable.put(preparedRowResult.row);
+        });
+
+        await this.afterLocalRowsChanged(listId, localTable);
+        return { success: true };
+      }
+
+      const preparedRowsByLogicalPrimaryKey = new Map<
+        IDBValidKey,
+        StoredLocalRow
+      >();
+      const rowsWithoutLogicalPrimaryKey: StoredLocalRow[] = [];
+
+      for (const item of items) {
+        const preparedRowResult = this.prepareLocalRow(listId, item, options);
+        if (!preparedRowResult.success) {
+          return preparedRowResult;
+        }
+
+        if (preparedRowResult.row.p === undefined) {
+          rowsWithoutLogicalPrimaryKey.push(preparedRowResult.row);
+          continue;
+        }
+
+        const existingRow = existingRowByLogicalPrimaryKey.get(
+          preparedRowResult.row.p,
+        );
+        preparedRowsByLogicalPrimaryKey.set(preparedRowResult.row.p, {
+          ...preparedRowResult.row,
+          i: existingRow?.i ?? preparedRowResult.row.i,
+        });
+      }
+
+      const limitCheckResult = this.checkPutLocalRowLimit(
+        listId,
+        existingRows,
+        [
+          ...preparedRowsByLogicalPrimaryKey.values(),
+          ...rowsWithoutLogicalPrimaryKey,
+        ],
+      );
+      if (!limitCheckResult.success) {
+        return limitCheckResult;
+      }
+
+      const localDatabase = await this.getWritableLocalDatabase(listId);
+      const localTable = localDatabase.rows;
+      await localDatabase.db.transaction("rw", localTable, async () => {
+        for (const [
+          logicalPrimaryKey,
+          preparedRow,
+        ] of preparedRowsByLogicalPrimaryKey) {
+          const existingRow =
+            existingRowByLogicalPrimaryKey.get(logicalPrimaryKey);
+          if (existingRow) {
+            await localTable.put({
+              ...preparedRow,
+              i: existingRow.i,
+            });
+            continue;
+          }
+
+          await localTable.add(preparedRow);
+        }
+
+        if (rowsWithoutLogicalPrimaryKey.length > 0) {
+          await localTable.bulkPut(rowsWithoutLogicalPrimaryKey);
+        }
+      });
+
+      await this.afterLocalRowsChanged(listId, localTable);
+      return { success: true };
+    });
+  }
+
+  public async setLocalItems(
+    listId: StaticListId,
+    items: unknown[],
+    options?: { validate?: boolean },
+  ): Promise<LocalWriteResult> {
+    const limit = this.getLocalRowLimit(listId);
+    if (items.length > limit) {
+      return {
+        success: false,
+        error: "localRowLimitExceeded",
+        limit,
+        attempting: items.length,
+      };
+    }
+
+    const preparedRows: StoredLocalRow[] = [];
+    for (const item of items) {
+      const preparedRowResult = this.prepareLocalRow(listId, item, options);
+      if (!preparedRowResult.success) {
+        return preparedRowResult;
+      }
+
+      preparedRows.push(preparedRowResult.row);
+    }
+
+    return await this.withLocalMutationLock(listId, async () => {
+      if (preparedRows.length === 0) {
+        await this.afterLocalRowsChanged(listId);
+        return { success: true };
+      }
+
+      const localDatabase = await this.getWritableLocalDatabase(listId);
+      const localTable = localDatabase.rows;
+      await localDatabase.db.transaction("rw", localTable, async () => {
+        await localTable.clear();
+        if (preparedRows.length > 0) {
+          await localTable.bulkAdd(preparedRows);
+        }
+      });
+
+      await this.afterLocalRowsChanged(listId, localTable);
+      return { success: true };
+    });
+  }
+
+  public async removeLocalItem(
+    listId: StaticListId,
+    target: RemoveLocalItemTarget | string,
+    value?: unknown,
+  ): Promise<{ deletedCount: number }> {
+    return await this.withLocalMutationLock(listId, async () => {
+      const normalizedTarget = coerceLegacyRemoveLocalItemTarget(
+        listId,
+        target,
+        value,
+      );
+      const localTable = await this.getLocalTable(listId, {
+        createIfMissing: false,
+      });
+      if (!localTable) {
+        return { deletedCount: 0 };
+      }
+
+      const deletedCount =
+        "rowKey" in normalizedTarget
+          ? await localTable.where("i").equals(normalizedTarget.rowKey).delete()
+          : await localTable
+              .where("p")
+              .equals(toIndexableType(normalizedTarget.logicalPrimaryKey))
+              .delete();
+
+      if (deletedCount === 0) {
+        return { deletedCount };
+      }
+
+      await this.afterLocalRowsChanged(listId, localTable);
+      return { deletedCount };
+    });
+  }
+
+  public async getEntriesPage(
+    listId: StaticListId,
+    params: { offset: number; limit: number },
+  ): Promise<{
+    items: StaticListPageEntry[];
+    totalCount: number;
+  }> {
     const metadata = await this.getListMetadata(listId);
-    const combiningMode = metadata.combiningMode;
 
-    if (combiningMode === "localOnly") {
-      return this.getLocalTable(listId).count();
+    if (metadata.combiningMode === "localOnly") {
+      const localTable = await this.getLocalTable(listId, {
+        createIfMissing: false,
+      });
+      const sortedLocalRows = sortLocalRows(
+        localTable ? await localTable.toArray() : [],
+      );
+      const pageRows = sortedLocalRows.slice(
+        params.offset,
+        params.offset + params.limit,
+      );
+
+      return {
+        items: pageRows.map((row) =>
+          createPageEntryFromStoredRow(listId, row, "local"),
+        ),
+        totalCount: sortedLocalRows.length,
+      };
     }
 
-    const remoteTable = await this.getActiveRemoteTable(listId);
+    const activeRemoteTable = await this.getActiveRemoteTable(listId);
+    const remoteStoredCount = activeRemoteTable
+      ? await activeRemoteTable.count()
+      : 0;
 
-    if (combiningMode === "remoteOnly") {
-      return remoteTable.count();
+    if (metadata.combiningMode === "remoteOnly") {
+      const pageRows = activeRemoteTable
+        ? await activeRemoteTable
+            .orderBy("r")
+            .offset(params.offset)
+            .limit(params.limit)
+            .toArray()
+        : [];
+
+      return {
+        items: pageRows.map((row) =>
+          createPageEntryFromStoredRow(listId, row, "remote"),
+        ),
+        totalCount: remoteStoredCount,
+      };
     }
 
-    // remoteWithLocalOverrides: remote count + pure-local additions
-    const remoteCount = await remoteTable.count();
-    const pureLocalCount = await this.countPureLocalItems(listId);
-    return remoteCount + pureLocalCount;
+    const localTable = await this.getLocalTable(listId, {
+      createIfMissing: false,
+    });
+    const localRows = sortLocalRows(
+      localTable ? await localTable.toArray() : [],
+    );
+    const localOverrideByLogicalPrimaryKey = new Map<
+      IDBValidKey,
+      StoredLocalRow
+    >();
+
+    for (const localRow of localRows) {
+      if (
+        localRow.p !== undefined &&
+        !localOverrideByLogicalPrimaryKey.has(localRow.p)
+      ) {
+        localOverrideByLogicalPrimaryKey.set(localRow.p, localRow);
+      }
+    }
+
+    const pureLocalRows = await this.getPureLocalRows(listId);
+    const totalCount = remoteStoredCount + pureLocalRows.length;
+
+    if (params.offset >= remoteStoredCount) {
+      const localOffset = params.offset - remoteStoredCount;
+      const pageRows = pureLocalRows.slice(
+        localOffset,
+        localOffset + params.limit,
+      );
+
+      return {
+        items: pageRows.map((row) =>
+          createPageEntryFromStoredRow(listId, row, "local"),
+        ),
+        totalCount,
+      };
+    }
+
+    const remotePageRows = activeRemoteTable
+      ? await activeRemoteTable
+          .orderBy("r")
+          .offset(params.offset)
+          .limit(params.limit)
+          .toArray()
+      : [];
+
+    // The merged sequence keeps the remote segment length stable, even when a
+    // local row shadows one or more remote rows. That stability is the paging
+    // contract for combined mode: offsets stay "remote segment first, pure
+    // local tail second" without rebuilding the whole merged list in memory.
+    const shadowedRemoteRowKeysByLogicalPrimaryKey = new Map<
+      IDBValidKey,
+      IDBValidKey[]
+    >();
+
+    for (const remoteRow of remotePageRows) {
+      if (
+        activeRemoteTable &&
+        remoteRow.p !== undefined &&
+        localOverrideByLogicalPrimaryKey.has(remoteRow.p) &&
+        !shadowedRemoteRowKeysByLogicalPrimaryKey.has(remoteRow.p)
+      ) {
+        const shadowedRemotePrimaryKeys = await activeRemoteTable
+          .where("p")
+          .equals(toIndexableType(remoteRow.p))
+          .primaryKeys();
+
+        shadowedRemoteRowKeysByLogicalPrimaryKey.set(
+          remoteRow.p,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie primaryKeys() is untyped to the queried index slot, but this query returns remote row primary keys
+          shadowedRemotePrimaryKeys as IDBValidKey[],
+        );
+      }
+    }
+
+    const items = remotePageRows.map((remoteRow) => {
+      if (
+        remoteRow.p !== undefined &&
+        localOverrideByLogicalPrimaryKey.has(remoteRow.p)
+      ) {
+        const localOverrideRow = localOverrideByLogicalPrimaryKey.get(
+          remoteRow.p,
+        );
+        if (!localOverrideRow) {
+          return createPageEntryFromStoredRow(listId, remoteRow, "remote");
+        }
+
+        return createPageEntryFromStoredRow(
+          listId,
+          localOverrideRow,
+          "localOverride",
+          shadowedRemoteRowKeysByLogicalPrimaryKey.get(remoteRow.p) ?? [],
+        );
+      }
+
+      return createPageEntryFromStoredRow(listId, remoteRow, "remote");
+    });
+
+    const remaining = params.limit - items.length;
+    if (remaining > 0) {
+      for (const localRow of pureLocalRows.slice(0, remaining)) {
+        items.push(createPageEntryFromStoredRow(listId, localRow, "local"));
+      }
+    }
+
+    return { items, totalCount };
   }
 
   public async getItemsPage(
@@ -1020,406 +1785,46 @@ export class StaticListsService {
     }>;
     totalCount: number;
   }> {
-    const metadata = await this.getListMetadata(listId);
-    const combiningMode = metadata.combiningMode;
-    const listDefinition = staticListDefinitionLookup[listId];
-
-    function validateItem(item: unknown): boolean {
-      return listDefinition.storedItemSchema.safeParse(item).success;
-    }
-
-    if (combiningMode === "localOnly") {
-      const localTable = this.getLocalTable(listId);
-      const totalCount = await localTable.count();
-      const rawItems = await localTable
-        .offset(params.offset)
-        .limit(params.limit)
-        .toArray();
-
-      return {
-        items: rawItems.map((item) => ({
-          item,
-          origin: "local" satisfies StaticListItemOrigin,
-          valid: validateItem(item),
-        })),
-        totalCount,
-      };
-    }
-
-    const remoteTable = await this.getActiveRemoteTable(listId);
-
-    if (combiningMode === "remoteOnly") {
-      const totalCount = await remoteTable.count();
-      const rawItems = await remoteTable
-        .offset(params.offset)
-        .limit(params.limit)
-        .toArray();
-
-      return {
-        items: rawItems.map((item) => ({
-          item,
-          origin: "remote" satisfies StaticListItemOrigin,
-          valid: validateItem(item),
-        })),
-        totalCount,
-      };
-    }
-
-    // remoteWithLocalOverrides
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- indexes are always strings (object keys)
-    const firstIndex = listDefinition.indexes[0] as string;
-
-    // Load all local items (always small set)
-    const localItems = await this.getLocalTable(listId).toArray();
-    const localByKey = new Map<unknown, unknown>();
-    for (const item of localItems) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-      localByKey.set((item as Record<string, unknown>)[firstIndex], item);
-    }
-
-    const remoteCount = await remoteTable.count();
-
-    // Count pure-local items (not overriding any remote)
-    const pureLocalItems: unknown[] = [];
-    for (const [key, item] of localByKey) {
-      const remoteMatch = await remoteTable.get({ [firstIndex]: key });
-      if (!remoteMatch) {
-        pureLocalItems.push(item);
-      }
-    }
-
-    const totalCount = remoteCount + pureLocalItems.length;
-
-    // If offset is within the remote range, read from remote table
-    if (params.offset < remoteCount) {
-      const rawRemoteItems = await remoteTable
-        .offset(params.offset)
-        .limit(params.limit)
-        .toArray();
-
-      type PageItem = {
-        item: unknown;
-        origin: StaticListItemOrigin;
-        valid: boolean;
-      };
-
-      const items: PageItem[] = rawRemoteItems.map((remoteItem) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-        const key = (remoteItem as Record<string, unknown>)[firstIndex];
-        const localItem = localByKey.get(key);
-        if (localItem) {
-          return {
-            item: localItem,
-            origin: "localOverride" satisfies StaticListItemOrigin,
-            valid: validateItem(localItem),
-          };
-        }
-        return {
-          item: remoteItem,
-          origin: "remote" satisfies StaticListItemOrigin,
-          valid: validateItem(remoteItem),
-        };
-      });
-
-      // If we got fewer items than the limit and there are pure-local items to append
-      const remaining = params.limit - items.length;
-      if (remaining > 0 && pureLocalItems.length > 0) {
-        for (const item of pureLocalItems.slice(0, remaining)) {
-          items.push({
-            item,
-            origin: "local" satisfies StaticListItemOrigin,
-            valid: validateItem(item),
-          });
-        }
-      }
-
-      return { items, totalCount };
-    }
-
-    // Offset is beyond remote items — serve from pure-local items
-    const pureLocalOffset = params.offset - remoteCount;
-    const pureLocalPage = pureLocalItems.slice(
-      pureLocalOffset,
-      pureLocalOffset + params.limit,
-    );
+    const result = await this.getEntriesPage(listId, params);
 
     return {
-      items: pureLocalPage.map((item) => ({
-        item,
-        origin: "local" satisfies StaticListItemOrigin,
-        valid: validateItem(item),
+      totalCount: result.totalCount,
+      items: result.items.map((entry) => ({
+        item: entry.interpretation.success
+          ? entry.interpretation.item
+          : {
+              sourceText: entry.sourceText,
+              sourceItem: entry.sourceItem,
+            },
+        origin: entry.origin,
+        valid: entry.interpretation.success,
       })),
-      totalCount,
     };
   }
-
-  public async searchItems(
-    listId: StaticListId,
-    params: { index: string; value: unknown },
-  ): Promise<{
-    items: Array<{
-      item: unknown;
-      origin: StaticListItemOrigin;
-      valid: boolean;
-    }>;
-  }> {
-    const metadata = await this.getListMetadata(listId);
-    const combiningMode = metadata.combiningMode;
-    const listDefinition = staticListDefinitionLookup[listId];
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- indexes are always strings (object keys)
-    const firstIndex = listDefinition.indexes[0] as string;
-
-    function validateItem(item: unknown): boolean {
-      return listDefinition.storedItemSchema.safeParse(item).success;
-    }
-
-    const localTable = this.getLocalTable(listId);
-    const remoteTable = await this.getActiveRemoteTable(listId);
-
-    if (combiningMode === "localOnly") {
-      const rawItems = await localTable
-        .where({ [params.index]: params.value })
-        .toArray();
-      return {
-        items: rawItems.map((item) => ({
-          item,
-          origin: "local" satisfies StaticListItemOrigin,
-          valid: validateItem(item),
-        })),
-      };
-    }
-
-    if (combiningMode === "remoteOnly") {
-      const rawItems = await remoteTable
-        .where({ [params.index]: params.value })
-        .toArray();
-      return {
-        items: rawItems.map((item) => ({
-          item,
-          origin: "remote" satisfies StaticListItemOrigin,
-          valid: validateItem(item),
-        })),
-      };
-    }
-
-    // remoteWithLocalOverrides: search both, deduplicate by first index
-    const remoteItems = await remoteTable
-      .where({ [params.index]: params.value })
-      .toArray();
-    const localItems = await localTable
-      .where({ [params.index]: params.value })
-      .toArray();
-
-    const localByKey = new Map<unknown, unknown>();
-    for (const item of localItems) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-      localByKey.set((item as Record<string, unknown>)[firstIndex], item);
-    }
-
-    type PageItem = {
-      item: unknown;
-      origin: StaticListItemOrigin;
-      valid: boolean;
-    };
-
-    const seenKeys = new Set<unknown>();
-    const items: PageItem[] = [];
-
-    for (const remoteItem of remoteItems) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-      const key = (remoteItem as Record<string, unknown>)[firstIndex];
-      seenKeys.add(key);
-
-      const localItem = localByKey.get(key);
-      if (localItem) {
-        items.push({
-          item: localItem,
-          origin: "localOverride",
-          valid: validateItem(localItem),
-        });
-      } else {
-        items.push({
-          item: remoteItem,
-          origin: "remote",
-          valid: validateItem(remoteItem),
-        });
-      }
-    }
-
-    // Add pure-local items not already seen
-    for (const [key, item] of localByKey) {
-      if (!seenKeys.has(key)) {
-        items.push({
-          item,
-          origin: "local",
-          valid: validateItem(item),
-        });
-      }
-    }
-
-    return { items };
-  }
-
-  private async countPureLocalItems(listId: StaticListId): Promise<number> {
-    const listDefinition = staticListDefinitionLookup[listId];
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- indexes are always strings (object keys)
-    const firstIndex = listDefinition.indexes[0] as string;
-
-    const localItems = await this.getLocalTable(listId).toArray();
-    const remoteTable = await this.getActiveRemoteTable(listId);
-
-    let count = 0;
-    for (const localItem of localItems) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-      const key = (localItem as Record<string, unknown>)[firstIndex];
-      const remoteMatch = await remoteTable.get({ [firstIndex]: key });
-      if (!remoteMatch) {
-        count += 1;
-      }
-    }
-    return count;
-  }
-
-  // ── Summary recomputation ──────────────────────────────────────────
-
-  private async recomputeLocalAndCombinedSummary(
-    listId: StaticListId,
-  ): Promise<void> {
-    const listDefinition: StaticListDefinition =
-      staticListDefinitionLookup[listId];
-    const localItems = await this.getLocalTable(listId).toArray();
-
-    const mutableLocalSummary = listDefinition.createEmptySummary();
-    for (const item of localItems) {
-      listDefinition.mutateSummary(mutableLocalSummary, item);
-    }
-
-    const metadata = await this.getListMetadata(listId);
-    const updatedMetadata = await this.recomputeCombinedSummaryForMetadata(
-      listId,
-      {
-        ...metadata,
-        localSummary: structuredClone(mutableLocalSummary),
-        localUpdatedAt: isoDateTimeSchema.parse(Date.now()),
-      },
-    );
-    this.setListMetadata(updatedMetadata);
-  }
-
-  private async recomputeCombinedSummaryForMetadata(
-    listId: StaticListId,
-    metadata: StaticListMetadata,
-  ): Promise<StaticListMetadata> {
-    const combiningMode = metadata.combiningMode;
-    const listDefinition: StaticListDefinition =
-      staticListDefinitionLookup[listId];
-
-    let combinedSummary: NonNullable<StaticListMetadata["combinedSummary"]>;
-
-    if (combiningMode === "remoteOnly") {
-      combinedSummary =
-        metadata.remoteActive?.summary ?? listDefinition.createEmptySummary();
-    } else if (combiningMode === "localOnly") {
-      combinedSummary =
-        metadata.localSummary ?? listDefinition.createEmptySummary();
-    } else {
-      // remoteWithLocalOverrides — start with remote, adjust for local items
-      const remoteSummaryRaw = metadata.remoteActive?.summary;
-      const remoteSummaryResult =
-        listDefinition.summarySchema.safeParse(remoteSummaryRaw);
-      const mutableCombined: WritableDeep<StaticListSummary> = structuredClone(
-        remoteSummaryResult.data ?? listDefinition.createEmptySummary(),
-      );
-
-      const localItems = await this.getLocalTable(listId).toArray();
-      const remoteTable = await this.getActiveRemoteTable(listId);
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- indexes are always strings (object keys)
-      const firstIndex = listDefinition.indexes[0] as string;
-
-      for (const localItem of localItems) {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown, accessing by dynamic key
-        const localItemKey = (localItem as Record<string, unknown>)[firstIndex];
-        const matchingRemoteItem = await remoteTable.get({
-          [firstIndex]: localItemKey,
-        });
-
-        if (matchingRemoteItem) {
-          // Override: remove the remote item's contribution, add local item's
-          listDefinition.unmutateSummary(mutableCombined, matchingRemoteItem);
-        }
-        // Either way, add the local item's contribution
-        listDefinition.mutateSummary(mutableCombined, localItem);
-      }
-
-      combinedSummary = mutableCombined;
-    }
-
-    return { ...metadata, combinedSummary };
-  }
-
-  // ── Public data access ─────────────────────────────────────────────
 
   async getItems<ListId extends StaticListId>(
     listId: ListId,
   ): Promise<Array<StaticListItem<ListId>>> {
-    const metadata = await this.getListMetadata(listId);
-    const combiningMode = metadata.combiningMode;
-
-    if (combiningMode === "localOnly") {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- data type is unknown, but we've parsed it with the right schema
-      return (await this.getLocalTable(listId).toArray()) as Array<
-        StaticListItem<ListId>
-      >;
+    const totalCount = await this.getVisibleEntryCount(listId);
+    if (totalCount > maxGetItemsCount) {
+      this.getListLogger(listId).error(
+        "getItems() is disabled for lists above {maxGetItemsCount} rows",
+        { maxGetItemsCount },
+      );
+      return [];
     }
 
-    const remoteTable = await this.getActiveRemoteTable(listId);
-
-    if (combiningMode === "remoteOnly") {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- data type is unknown, but we've parsed it with the right schema
-      return (await remoteTable.toArray()) as Array<StaticListItem<ListId>>;
-    }
-
-    // remoteWithLocalOverrides
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown
-    const remoteItems = (await remoteTable.toArray()) as Array<
-      StaticListItem<ListId>
-    >;
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Dexie stores items as unknown
-    const localItems = (await this.getLocalTable(listId).toArray()) as Array<
-      StaticListItem<ListId>
-    >;
-
-    if (localItems.length === 0) {
-      return remoteItems;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- indexes are always strings (object keys)
-    const firstIndex = staticListDefinitionLookup[listId].indexes[0] as string;
-
-    const localByKey = new Map<unknown, StaticListItem<ListId>>();
-    for (const item of localItems) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- accessing item by dynamic key
-      localByKey.set((item as Record<string, unknown>)[firstIndex], item);
-    }
-
-    const result: Array<StaticListItem<ListId>> = remoteItems.map((item) => {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- accessing item by dynamic key
-      const key = (item as Record<string, unknown>)[firstIndex];
-      return localByKey.get(key) ?? item;
+    const page = await this.getEntriesPage(listId, {
+      offset: 0,
+      limit: totalCount,
     });
 
-    // Append pure-local items (not overriding any remote)
-    const remoteKeys = new Set(
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- accessing item by dynamic key
-      remoteItems.map((item) => (item as Record<string, unknown>)[firstIndex]),
+    return page.items.flatMap((entry) =>
+      entry.interpretation.success
+        ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- getItems() filters to successful interpretations before projecting them to the list-specific item type
+          [entry.interpretation.item as StaticListItem<ListId>]
+        : [],
     );
-    for (const [key, item] of localByKey) {
-      if (!remoteKeys.has(key)) {
-        result.push(item);
-      }
-    }
-
-    return result;
   }
 
   async pollItems<ListId extends StaticListId>(
@@ -1428,74 +1833,98 @@ export class StaticListsService {
   ): Promise<PollResult<Array<StaticListItem<ListId>>>> {
     const metadataResult = await this.pollListMetadata(lastPollVersion, listId);
     return {
-      value: await this.getItems(listId),
       version: metadataResult.version,
+      value: await this.getItems(listId),
     };
   }
 
   async findItem<
     ListId extends StaticListId,
     Index extends keyof z.infer<
-      (typeof staticListDefinitionLookup)[ListId]["storedItemSchema"]
+      (typeof staticListDefinitionLookup)[ListId]["interpretedItemSchema"]
     >,
   >(
     listId: ListId,
     index: Index,
     value: z.infer<
-      (typeof staticListDefinitionLookup)[ListId]["storedItemSchema"]
+      (typeof staticListDefinitionLookup)[ListId]["interpretedItemSchema"]
     >[Index],
-    options?: { origin?: "remote" | "local" },
   ): Promise<StaticListItem<ListId> | undefined> {
-    const listLogger = this.getListLogger(listId);
-    const staticListDefinition = staticListDefinitionLookup[listId];
+    // Business reads intentionally stay typed and lossy: once a local row
+    // shadows a remote row, malformed local data makes the item behave as
+    // absent rather than silently falling back to the remote snapshot.
+    if (value === undefined) {
+      return undefined;
+    }
 
-    async function findInTable(
-      table: Table<unknown>,
-    ): Promise<StaticListItem<ListId> | undefined> {
-      const rawItem = await table.get({ [index]: value });
-      if (!rawItem) {
+    const slotName = this.resolveSlotName(listId, String(index));
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- declared indexes are limited to IDB-valid key domains for this API
+    const lookupValue = value as IDBValidKey;
+    const localTable = await this.getLocalTable(listId, {
+      createIfMissing: false,
+    });
+    const activeRemoteTable = await this.getActiveRemoteTable(listId);
+
+    function interpretTypedItem(
+      storedRow: StoredLocalRow | StoredRemoteRow | undefined,
+      origin: StaticListItemOrigin,
+    ): StaticListItem<ListId> | undefined {
+      if (!storedRow) {
         return undefined;
       }
 
-      const parsedItem =
-        staticListDefinition.storedItemSchema.safeParse(rawItem);
-
-      if (!parsedItem.success) {
-        listLogger.error("Invalid item {rawItem}: {error}", {
-          rawItem,
-          error: parsedItem.error.message,
-        });
+      const interpretedRow = interpretStoredRow(listId, storedRow, origin);
+      if (!interpretedRow.interpretation.success) {
         return undefined;
       }
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- data type is unknown, but we've parsed it with the right schema
-      return parsedItem.data as StaticListItem<ListId>;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the interpreted item belongs to the same list id used to query and interpret the row
+      return interpretedRow.interpretation.item as StaticListItem<ListId>;
     }
 
-    // Explicit origin bypasses combining mode
-    if (options?.origin === "remote") {
-      return findInTable(await this.getActiveRemoteTable(listId));
-    }
-    if (options?.origin === "local") {
-      return findInTable(this.getLocalTable(listId));
-    }
-
-    // Default: follow combining mode
     const metadata = await this.getListMetadata(listId);
-    const combiningMode = metadata.combiningMode;
+    if (metadata.combiningMode === "localOnly") {
+      return interpretTypedItem(
+        localTable
+          ? await this.findRowInTable(localTable, slotName, lookupValue)
+          : undefined,
+        "local",
+      );
+    }
 
-    if (combiningMode === "remoteOnly") {
-      return findInTable(await this.getActiveRemoteTable(listId));
-    }
-    if (combiningMode === "localOnly") {
-      return findInTable(this.getLocalTable(listId));
+    if (metadata.combiningMode === "remoteOnly") {
+      return interpretTypedItem(
+        activeRemoteTable
+          ? await this.findRowInTable(activeRemoteTable, slotName, lookupValue)
+          : undefined,
+        "remote",
+      );
     }
 
-    // remoteWithLocalOverrides: check local first, fall back to remote
-    const localResult = await findInTable(this.getLocalTable(listId));
-    if (localResult) {
-      return localResult;
+    const localMatch = localTable
+      ? await this.findRowInTable(localTable, slotName, lookupValue)
+      : undefined;
+    if (localMatch) {
+      return interpretTypedItem(localMatch, "local");
     }
-    return findInTable(await this.getActiveRemoteTable(listId));
+
+    const remoteMatch = activeRemoteTable
+      ? await this.findRowInTable(activeRemoteTable, slotName, lookupValue)
+      : undefined;
+    if (!remoteMatch) {
+      return undefined;
+    }
+
+    if (remoteMatch.p !== undefined && localTable) {
+      const overridingLocalRow = await localTable
+        .where("p")
+        .equals(toIndexableType(remoteMatch.p))
+        .first();
+      if (overridingLocalRow) {
+        return undefined;
+      }
+    }
+
+    return interpretTypedItem(remoteMatch, "remote");
   }
 }

--- a/src/entrypoints/background/@services/static-lists-service/definition-helpers.ts
+++ b/src/entrypoints/background/@services/static-lists-service/definition-helpers.ts
@@ -1,0 +1,96 @@
+import type {
+  StaticListDefinition,
+  StaticListIndexDefinition,
+} from "@/shared/@model/static-list-helpers";
+import {
+  staticListDefinitionLookup,
+  type StaticListId,
+  staticListIds,
+} from "@/shared/@model/static-lists";
+
+import type { StoredRowIndexSlotName } from "./types";
+
+type StaticListIndexSlotDefinition = {
+  slotName: StoredRowIndexSlotName;
+  definition: StaticListIndexDefinition<unknown>;
+};
+
+export type StaticListDefinitionInfo = {
+  listId: StaticListId;
+  definition: StaticListDefinition;
+  logicalPrimaryKeySlot: StaticListIndexSlotDefinition & { slotName: "p" };
+  secondaryIndexSlots: StaticListIndexSlotDefinition[];
+  allIndexSlots: StaticListIndexSlotDefinition[];
+  publicIndexNames: string[];
+  publicIndexNameToSlotName: Readonly<Record<string, StoredRowIndexSlotName>>;
+};
+
+const definitionInfoByListIdPartial: Partial<
+  Record<StaticListId, StaticListDefinitionInfo>
+> = {};
+
+for (const listId of staticListIds) {
+  const definition = staticListDefinitionLookup[listId];
+  const logicalPrimaryKeySlot = {
+    slotName: "p" as const,
+    definition:
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- runtime definition registry intentionally erases per-list generics into shared slot metadata
+      definition.logicalPrimaryKey as StaticListIndexDefinition<unknown>,
+  };
+
+  const secondaryIndexSlots = (definition.secondaryIndexes ?? []).map(
+    (secondaryIndex, index) => ({
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- runtime slot names are generated from the secondary index position
+      slotName: `s${index + 1}` as StoredRowIndexSlotName,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- runtime definition registry intentionally erases per-list generics into shared slot metadata
+      definition: secondaryIndex as StaticListIndexDefinition<unknown>,
+    }),
+  );
+
+  const allIndexSlots = [logicalPrimaryKeySlot, ...secondaryIndexSlots];
+  const publicIndexNameToSlotNameEntries = allIndexSlots.map((indexSlot) => [
+    indexSlot.definition.name,
+    indexSlot.slotName,
+  ]);
+
+  definitionInfoByListIdPartial[listId] = {
+    listId,
+    definition,
+    logicalPrimaryKeySlot,
+    secondaryIndexSlots,
+    allIndexSlots,
+    publicIndexNames: allIndexSlots.map(
+      (indexSlot) => indexSlot.definition.name,
+    ),
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Object.fromEntries cannot preserve the slot-name value type here
+    publicIndexNameToSlotName: Object.fromEntries(
+      publicIndexNameToSlotNameEntries,
+    ) as Record<string, StoredRowIndexSlotName>,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the loop above populates every static list id before the readonly view is exposed
+const definitionInfoByListId = definitionInfoByListIdPartial as Readonly<
+  Record<StaticListId, StaticListDefinitionInfo>
+>;
+
+export function getStaticListDefinitionInfo(
+  listId: StaticListId,
+): StaticListDefinitionInfo {
+  return definitionInfoByListId[listId];
+}
+
+export function buildRowStoreSchema({
+  physicalKey,
+  secondaryIndexCount,
+}: {
+  physicalKey: "r" | "i";
+  secondaryIndexCount: number;
+}): string {
+  const secondarySlots = Array.from(
+    { length: secondaryIndexCount },
+    (_, index) => `s${index + 1}`,
+  );
+
+  return [physicalKey, "p", ...secondarySlots].join(", ");
+}

--- a/src/entrypoints/background/@services/static-lists-service/interpretation.ts
+++ b/src/entrypoints/background/@services/static-lists-service/interpretation.ts
@@ -1,0 +1,109 @@
+import type { JsonValue } from "type-fest";
+
+import type { StaticListItemOrigin } from "@/shared/@model/static-list-helpers";
+import type { StaticListId } from "@/shared/@model/static-lists";
+
+import { getStaticListDefinitionInfo } from "./definition-helpers";
+import type {
+  InterpretedStoredRowResult,
+  StoredRow,
+  StoredRowCachedIndexValues,
+} from "./types";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isSecondaryIndexSlotName(key: string): key is `s${number}` {
+  return /^s\d+$/.test(key);
+}
+
+export function extractCachedIndexValues(
+  storedRow: StoredRow,
+): StoredRowCachedIndexValues {
+  const indexValues: StoredRowCachedIndexValues = {};
+
+  if (storedRow.p !== undefined) {
+    indexValues.p = storedRow.p;
+  }
+
+  for (const [key, value] of Object.entries(storedRow)) {
+    if (isSecondaryIndexSlotName(key) && value !== undefined) {
+      indexValues[key] = value;
+    }
+  }
+
+  return indexValues;
+}
+
+export function getStoredRowKey(storedRow: StoredRow): string | number {
+  return "r" in storedRow ? storedRow.r : storedRow.i;
+}
+
+/**
+ * This is the single seam that turns source-preserving storage back into typed
+ * runtime data.
+ *
+ * Keeping every read path on top of the same helper is what lets remote rows be
+ * stored raw, local malformed rows remain inspectable, and sidepanel/business
+ * reads agree on where parse failures begin.
+ */
+export function interpretStoredRow(
+  listId: StaticListId,
+  storedRow: StoredRow,
+  origin: StaticListItemOrigin,
+): InterpretedStoredRowResult {
+  const definitionInfo = getStaticListDefinitionInfo(listId);
+
+  let parsedJson: JsonValue | undefined;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- JSON.parse output is validated by jsonlItemSchema before interpretation and returned as raw sourceItem otherwise
+    parsedJson = JSON.parse(storedRow.t);
+  } catch (error) {
+    return {
+      rowKey: getStoredRowKey(storedRow),
+      origin,
+      sourceText: storedRow.t,
+      sourceItem: undefined,
+      logicalPrimaryKey: storedRow.p,
+      cachedIndexValues: extractCachedIndexValues(storedRow),
+      interpretation: {
+        success: false,
+        kind: "jsonParse",
+        error: getErrorMessage(error),
+      },
+    };
+  }
+
+  const jsonlItemResult =
+    definitionInfo.definition.jsonlItemSchema.safeParse(parsedJson);
+
+  if (!jsonlItemResult.success) {
+    return {
+      rowKey: getStoredRowKey(storedRow),
+      origin,
+      sourceText: storedRow.t,
+      sourceItem: parsedJson,
+      logicalPrimaryKey: storedRow.p,
+      cachedIndexValues: extractCachedIndexValues(storedRow),
+      interpretation: {
+        success: false,
+        kind: "jsonlSchema",
+        error: jsonlItemResult.error.message,
+      },
+    };
+  }
+
+  return {
+    rowKey: getStoredRowKey(storedRow),
+    origin,
+    sourceText: storedRow.t,
+    sourceItem: parsedJson,
+    logicalPrimaryKey: storedRow.p,
+    cachedIndexValues: extractCachedIndexValues(storedRow),
+    interpretation: {
+      success: true,
+      item: definitionInfo.definition.interpretJsonlItem(jsonlItemResult.data),
+    },
+  };
+}

--- a/src/entrypoints/background/@services/static-lists-service/list-database.ts
+++ b/src/entrypoints/background/@services/static-lists-service/list-database.ts
@@ -1,0 +1,279 @@
+import { Dexie, type Table } from "dexie";
+
+import type { StaticListRemoteInstance } from "@/shared/@model/static-list-helpers";
+import type { StaticListId } from "@/shared/@model/static-lists";
+
+import {
+  buildRowStoreSchema,
+  getStaticListDefinitionInfo,
+} from "./definition-helpers";
+import type { StoredLocalRow, StoredRemoteRow } from "./types";
+
+const remoteDatabaseRoleByInstance = {
+  a: "remote_a",
+  b: "remote_b",
+} as const satisfies Record<StaticListRemoteInstance, `remote_${string}`>;
+
+const rowsStoreName = "rows";
+
+function getRowsDatabaseName({
+  listId,
+  databaseRole,
+}: {
+  listId: StaticListId;
+  databaseRole: "local" | `remote_${string}`;
+}): string {
+  return `static-lists:${listId}:${databaseRole}`;
+}
+
+export type StaticListRowsDatabase<Row, Key> = {
+  db: Dexie;
+  rows: Table<Row, Key>;
+};
+
+/**
+ * Each list gets physically separate `remote_a`, `remote_b`, and lazy `local`
+ * databases.
+ *
+ * The goal is operational simplicity rather than raw database cleverness:
+ * promoting a download becomes a metadata flip, stale remote snapshots can be
+ * deleted wholesale, and production users never create a local DB unless they
+ * actually touch dev-only features.
+ */
+function createRowsDatabase<Row, Key>({
+  listId,
+  databaseRole,
+  physicalKey,
+}: {
+  listId: StaticListId;
+  databaseRole: "local" | `remote_${string}`;
+  physicalKey: "r" | "i";
+}): StaticListRowsDatabase<Row, Key> {
+  const definitionInfo = getStaticListDefinitionInfo(listId);
+  const db = new Dexie(getRowsDatabaseName({ listId, databaseRole }));
+
+  db.version(definitionInfo.definition.physicalStorageVersion).stores({
+    [rowsStoreName]: buildRowStoreSchema({
+      physicalKey,
+      secondaryIndexCount: definitionInfo.secondaryIndexSlots.length,
+    }),
+  });
+
+  return {
+    db,
+    rows: db.table<Row, Key>(rowsStoreName),
+  };
+}
+
+function createRemoteRowsDatabase(
+  listId: StaticListId,
+  instance: StaticListRemoteInstance,
+): StaticListRowsDatabase<StoredRemoteRow, number> {
+  return createRowsDatabase({
+    listId,
+    databaseRole: remoteDatabaseRoleByInstance[instance],
+    physicalKey: "r",
+  });
+}
+
+function createLocalRowsDatabase(
+  listId: StaticListId,
+): StaticListRowsDatabase<StoredLocalRow, string> {
+  return createRowsDatabase({
+    listId,
+    databaseRole: "local",
+    physicalKey: "i",
+  });
+}
+
+export class StaticListDatabases {
+  private readonly listId: StaticListId;
+  private readonly remoteDatabaseByInstance: Record<
+    StaticListRemoteInstance,
+    StaticListRowsDatabase<StoredRemoteRow, number> | undefined
+  > = {
+    a: undefined,
+    b: undefined,
+  };
+  private readonly remoteDatabaseStateByInstance: Record<
+    StaticListRemoteInstance,
+    "unknown" | "present" | "absent"
+  > = {
+    a: "unknown",
+    b: "unknown",
+  };
+  private localDatabase:
+    | StaticListRowsDatabase<StoredLocalRow, string>
+    | undefined;
+  private localDatabaseState: "unknown" | "present" | "absent" = "unknown";
+
+  constructor(listId: StaticListId) {
+    this.listId = listId;
+  }
+
+  private async openRowsDatabase<Row, Key>(
+    database: StaticListRowsDatabase<Row, Key>,
+  ): Promise<StaticListRowsDatabase<Row, Key>> {
+    if (!database.db.isOpen()) {
+      await database.db.open();
+    }
+
+    return database;
+  }
+
+  private ensureRemoteDatabase(
+    instance: StaticListRemoteInstance,
+  ): StaticListRowsDatabase<StoredRemoteRow, number> {
+    this.remoteDatabaseByInstance[instance] ??= createRemoteRowsDatabase(
+      this.listId,
+      instance,
+    );
+    this.remoteDatabaseStateByInstance[instance] = "present";
+
+    return this.remoteDatabaseByInstance[instance];
+  }
+
+  public async getRemoteDatabase(
+    instance: StaticListRemoteInstance,
+    options?: { createIfMissing?: boolean },
+  ): Promise<StaticListRowsDatabase<StoredRemoteRow, number> | undefined> {
+    if (options?.createIfMissing === false) {
+      if (this.remoteDatabaseStateByInstance[instance] === "absent") {
+        return undefined;
+      }
+
+      if (
+        this.remoteDatabaseStateByInstance[instance] === "unknown" &&
+        !this.remoteDatabaseByInstance[instance] &&
+        !(await Dexie.exists(
+          getRowsDatabaseName({
+            listId: this.listId,
+            databaseRole: remoteDatabaseRoleByInstance[instance],
+          }),
+        ))
+      ) {
+        this.remoteDatabaseStateByInstance[instance] = "absent";
+        return undefined;
+      }
+    }
+
+    return await this.openRowsDatabase(this.ensureRemoteDatabase(instance));
+  }
+
+  public async getRemoteRows(
+    instance: StaticListRemoteInstance,
+    options?: { createIfMissing?: boolean },
+  ): Promise<Table<StoredRemoteRow, number> | undefined> {
+    const database = await this.getRemoteDatabase(instance, options);
+    return database?.rows;
+  }
+
+  public async resetRemoteDatabase(
+    instance: StaticListRemoteInstance,
+  ): Promise<StaticListRowsDatabase<StoredRemoteRow, number>> {
+    await this.deleteRemoteDatabase(instance);
+    const database = await this.getRemoteDatabase(instance);
+    if (!database) {
+      // eslint-disable-next-line no-restricted-syntax -- resetting a remote database must recreate it
+      throw new Error(`Failed to recreate remote database ${instance}`);
+    }
+
+    return database;
+  }
+
+  public async deleteRemoteDatabase(
+    instance: StaticListRemoteInstance,
+  ): Promise<void> {
+    const database =
+      this.remoteDatabaseByInstance[instance] ??
+      createRemoteRowsDatabase(this.listId, instance);
+
+    this.remoteDatabaseByInstance[instance] = undefined;
+    this.remoteDatabaseStateByInstance[instance] = "absent";
+    database.db.close();
+    await database.db.delete();
+  }
+
+  /**
+   * Remote-only resets are intentionally cheaper than full resets because
+   * remote data is reproducible while local rows may contain developer work.
+   */
+  public async deleteRemoteDatabases(): Promise<void> {
+    await Promise.all([
+      this.deleteRemoteDatabase("a"),
+      this.deleteRemoteDatabase("b"),
+    ]);
+  }
+
+  private ensureLocalDatabase(): StaticListRowsDatabase<
+    StoredLocalRow,
+    string
+  > {
+    this.localDatabase ??= createLocalRowsDatabase(this.listId);
+    this.localDatabaseState = "present";
+    return this.localDatabase;
+  }
+
+  public async getLocalDatabase(options?: {
+    createIfMissing?: boolean;
+  }): Promise<StaticListRowsDatabase<StoredLocalRow, string> | undefined> {
+    if (options?.createIfMissing === false) {
+      if (this.localDatabaseState === "absent") {
+        return undefined;
+      }
+
+      if (
+        this.localDatabaseState === "unknown" &&
+        !this.localDatabase &&
+        !(await Dexie.exists(
+          getRowsDatabaseName({
+            listId: this.listId,
+            databaseRole: "local",
+          }),
+        ))
+      ) {
+        this.localDatabaseState = "absent";
+        return undefined;
+      }
+    }
+
+    return await this.openRowsDatabase(this.ensureLocalDatabase());
+  }
+
+  public async getLocalRows(options?: {
+    createIfMissing?: boolean;
+  }): Promise<Table<StoredLocalRow, string> | undefined> {
+    const database = await this.getLocalDatabase(options);
+    return database?.rows;
+  }
+
+  public async deleteLocalDatabase(): Promise<void> {
+    if (!this.localDatabase && this.localDatabaseState === "absent") {
+      return;
+    }
+
+    const database = this.localDatabase ?? createLocalRowsDatabase(this.listId);
+
+    this.localDatabase = undefined;
+    this.localDatabaseState = "absent";
+    database.db.close();
+    await database.db.delete();
+  }
+
+  public async deleteAllDatabases(): Promise<void> {
+    await Promise.all([
+      this.deleteRemoteDatabases(),
+      this.deleteLocalDatabase(),
+    ]);
+  }
+
+  public closeAll(): void {
+    for (const database of Object.values(this.remoteDatabaseByInstance)) {
+      if (database) {
+        database.db.close();
+      }
+    }
+
+    this.localDatabase?.db.close();
+  }
+}

--- a/src/entrypoints/background/@services/static-lists-service/metadata-helpers.ts
+++ b/src/entrypoints/background/@services/static-lists-service/metadata-helpers.ts
@@ -1,0 +1,191 @@
+import type {
+  StaticListCombiningMode,
+  StaticListRemoteInstance,
+} from "@/shared/@model/static-list-helpers";
+import {
+  type StaticListMetadata,
+  staticListMetadataSchema,
+  type StoredStaticListMetadata,
+} from "@/shared/@model/static-list-metadata";
+import {
+  staticListDefinitionLookup,
+  type StaticListId,
+  type StaticListSummary,
+} from "@/shared/@model/static-lists";
+import type { IsoDateTime } from "@/shared/@primitives/temporal";
+
+import {
+  defineStoreWithSchema,
+  type StoreWithSchema,
+} from "../../@service-helpers/store-with-schema";
+
+const metadataStoreByListId: Partial<
+  Record<StaticListId, StoreWithSchema<typeof staticListMetadataSchema>>
+> = {};
+
+/**
+ * Metadata stays per-list and deliberately small.
+ *
+ * Local and combined summaries are cheap to recompute and are only useful in
+ * dev-only combining modes, so persisting them would make production users pay
+ * ongoing write/read complexity for state they never consume.
+ */
+export function getStaticListMetadataStore(
+  listId: StaticListId,
+): StoreWithSchema<typeof staticListMetadataSchema> {
+  metadataStoreByListId[listId] ??= defineStoreWithSchema(
+    `local:static-list-metadata:${listId}`,
+    staticListMetadataSchema,
+  );
+
+  return metadataStoreByListId[listId];
+}
+
+/**
+ * New lists start in `remoteOnly` so the production path has zero dependency on
+ * local/combined features until a developer opts in.
+ *
+ * The active instance starts at `b` so the first real download stages into `a`
+ * and uses the same promotion logic as every later refresh.
+ */
+export function createDefaultStaticListMetadata<ListId extends StaticListId>(
+  listId: ListId,
+): StaticListMetadata<ListId> {
+  const definition = staticListDefinitionLookup[listId];
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the metadata envelope is keyed by the same list id passed into the helper
+  return {
+    listId,
+    physicalStorageVersion: definition.physicalStorageVersion,
+    derivedDataVersion: definition.derivedDataVersion,
+    combiningMode: "remoteOnly",
+    remoteActiveInstance: "b",
+  } as StaticListMetadata<ListId>;
+}
+
+/**
+ * Summary validation is part of metadata parsing rather than a second step.
+ *
+ * Once metadata leaves this helper, callers should be able to trust both the
+ * envelope and the typed summary payloads. If persisted remote summaries are no
+ * longer readable, the service falls back to remote-state recovery instead of
+ * making every consumer re-parse `z.json()` payloads defensively.
+ */
+export function tryParseStaticListMetadata<ListId extends StaticListId>(
+  listId: ListId,
+  metadata: StoredStaticListMetadata,
+): StaticListMetadata<ListId> | undefined {
+  if (metadata.listId !== listId) {
+    return undefined;
+  }
+
+  const definition = staticListDefinitionLookup[listId];
+
+  const remoteActiveSummary = metadata.remoteActive
+    ? definition.summarySchema.safeParse(metadata.remoteActive.summary)
+    : undefined;
+  if (remoteActiveSummary && !remoteActiveSummary.success) {
+    return undefined;
+  }
+
+  const remoteStagingSummary = metadata.remoteStaging
+    ? definition.summarySchema.safeParse(metadata.remoteStaging.summary)
+    : undefined;
+  if (remoteStagingSummary && !remoteStagingSummary.success) {
+    return undefined;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- summary schemas were validated above; we are re-attaching the list-specific parsed summary shape to the stored metadata envelope
+  return {
+    ...metadata,
+    listId,
+    ...(metadata.remoteActive
+      ? {
+          remoteActive: {
+            ...metadata.remoteActive,
+            summary:
+              remoteActiveSummary?.data ??
+              staticListDefinitionLookup[listId].createEmptySummary(),
+          },
+        }
+      : {}),
+    ...(metadata.remoteStaging
+      ? {
+          remoteStaging: {
+            ...metadata.remoteStaging,
+            summary:
+              remoteStagingSummary?.data ??
+              staticListDefinitionLookup[listId].createEmptySummary(),
+          },
+        }
+      : {}),
+  } as StaticListMetadata<ListId>;
+}
+
+export function extractSummaryFromMetadata<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+  source: "remoteActive" | "remoteStaging" = "remoteActive",
+): StaticListSummary<ListId> {
+  if (source === "remoteActive") {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- metadata.listId and the selected definition stay correlated through the generic helper boundary
+    return (metadata.remoteActive?.summary ??
+      staticListDefinitionLookup[
+        metadata.listId
+      ].createEmptySummary()) as StaticListSummary<ListId>;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- metadata.listId and the selected definition stay correlated through the generic helper boundary
+  return (metadata.remoteStaging?.summary ??
+    staticListDefinitionLookup[
+      metadata.listId
+    ].createEmptySummary()) as StaticListSummary<ListId>;
+}
+
+export function tryExtractSummaryFromMetadata<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+  source: "remoteActive" | "remoteStaging" = "remoteActive",
+): StaticListSummary<ListId> | undefined {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- metadata.listId already determines the summary shape; this helper only selects the source
+  return (
+    source === "remoteActive"
+      ? metadata.remoteActive?.summary
+      : metadata.remoteStaging?.summary
+  ) as StaticListSummary<ListId> | undefined;
+}
+
+export function extractUpdatedAtFromMetadata<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+): IsoDateTime | undefined {
+  if (metadata.combiningMode === "remoteOnly") {
+    return metadata.remoteActive?.updatedAt;
+  }
+
+  if (metadata.combiningMode === "localOnly") {
+    return metadata.localUpdatedAt;
+  }
+
+  const remoteUpdatedAt = metadata.remoteActive?.updatedAt;
+  const localUpdatedAt = metadata.localUpdatedAt;
+
+  if (!remoteUpdatedAt) {
+    return localUpdatedAt;
+  }
+
+  if (!localUpdatedAt) {
+    return remoteUpdatedAt;
+  }
+
+  return [remoteUpdatedAt, localUpdatedAt].toSorted()[1];
+}
+
+export function pickAnotherRemoteInstance(
+  instance: StaticListRemoteInstance,
+): StaticListRemoteInstance {
+  return instance === "a" ? "b" : "a";
+}
+
+export function shouldComputeDevSummaries(
+  combiningMode: StaticListCombiningMode,
+): boolean {
+  return combiningMode !== "remoteOnly";
+}

--- a/src/entrypoints/background/@services/static-lists-service/row-helpers.ts
+++ b/src/entrypoints/background/@services/static-lists-service/row-helpers.ts
@@ -1,0 +1,191 @@
+import { nanoid } from "nanoid";
+
+import type {
+  StaticListId,
+  StaticListItem,
+} from "@/shared/@model/static-lists";
+import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
+
+import { getStaticListDefinitionInfo } from "./definition-helpers";
+import type {
+  StoredLocalRow,
+  StoredRemoteRow,
+  StoredRowCachedIndexValues,
+} from "./types";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function stringifyJsonlItem(listId: StaticListId, jsonlItem: unknown): string {
+  const definition = getStaticListDefinitionInfo(listId).definition;
+  return definition.jsonlStringifyRow?.(jsonlItem) ?? JSON.stringify(jsonlItem);
+}
+
+/**
+ * Cached index values are extracted from the JSONL-form source, not from the
+ * interpreted item.
+ *
+ * This keeps remote and local rows consistent with each other and avoids
+ * letting interpretation changes silently rewrite the stored meaning of old
+ * remote rows.
+ */
+export function extractCachedIndexValuesFromJsonlItem(
+  listId: StaticListId,
+  jsonlItem: unknown,
+): StoredRowCachedIndexValues {
+  const definitionInfo = getStaticListDefinitionInfo(listId);
+  const cachedIndexValues: StoredRowCachedIndexValues = {};
+
+  for (const indexSlot of definitionInfo.allIndexSlots) {
+    const extractedValue = indexSlot.definition.extractFromJsonlItem(jsonlItem);
+    if (extractedValue !== undefined) {
+      cachedIndexValues[indexSlot.slotName] = extractedValue;
+    }
+  }
+
+  return cachedIndexValues;
+}
+
+export function extractCachedIndexValuesFromSourceText(
+  listId: StaticListId,
+  sourceText: string,
+): StoredRowCachedIndexValues {
+  const definition = getStaticListDefinitionInfo(listId).definition;
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(sourceText);
+  } catch {
+    return {};
+  }
+
+  const jsonlItemResult = definition.jsonlItemSchema.safeParse(parsedJson);
+  if (!jsonlItemResult.success) {
+    return {};
+  }
+
+  return extractCachedIndexValuesFromJsonlItem(listId, jsonlItemResult.data);
+}
+
+export function createStoredRemoteRow({
+  listId,
+  lineNumber,
+  sourceText,
+}: {
+  listId: StaticListId;
+  lineNumber: number;
+  sourceText: string;
+}): StoredRemoteRow {
+  return {
+    r: lineNumber,
+    t: sourceText,
+    ...extractCachedIndexValuesFromSourceText(listId, sourceText),
+  };
+}
+
+function stringifyUnknownSource(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  const jsonString = JSON.stringify(value);
+  return typeof jsonString === "string" ? jsonString : String(value);
+}
+
+/**
+ * Validated local writes still round-trip through the JSONL serializer before
+ * hitting storage.
+ *
+ * That extra step is deliberate: local rows should obey the same raw-storage
+ * contract as remote rows so exports, key extraction, and future
+ * re-interpretation all see a single source-preserving format.
+ */
+export function prepareValidatedLocalRow({
+  listId,
+  item,
+  existingRowId,
+  updatedAt,
+}: {
+  listId: StaticListId;
+  item: unknown;
+  existingRowId: string | undefined;
+  updatedAt: number;
+}):
+  | { success: true; row: StoredLocalRow }
+  | { success: false; error: string; details?: unknown } {
+  const definition = getStaticListDefinitionInfo(listId).definition;
+  const interpretedItemResult =
+    definition.interpretedItemSchema.safeParse(item);
+
+  if (!interpretedItemResult.success) {
+    return {
+      success: false,
+      error: "interpretedItemSchema",
+      details: interpretedItemResult.error.message,
+    };
+  }
+
+  const jsonlItem = definition.serializeInterpretedItemAsJsonl(
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the parsed item was validated against this list definition's interpreted schema above
+    interpretedItemResult.data as StaticListItem,
+  );
+
+  const jsonlItemResult = definition.jsonlItemSchema.safeParse(jsonlItem);
+  if (!jsonlItemResult.success) {
+    return {
+      success: false,
+      error: "serializeInterpretedItemAsJsonl",
+      details: jsonlItemResult.error.message,
+    };
+  }
+
+  return {
+    success: true,
+    row: {
+      i: existingRowId ?? nanoid(),
+      u: isoDateTimeSchema.parse(updatedAt),
+      t: stringifyJsonlItem(listId, jsonlItemResult.data),
+      ...extractCachedIndexValuesFromJsonlItem(listId, jsonlItemResult.data),
+    },
+  };
+}
+
+/**
+ * Unvalidated local writes exist so the sidepanel can keep malformed rows
+ * inspectable and editable instead of rejecting them at write time.
+ *
+ * We still opportunistically cache keys when the raw text parses, because the
+ * ability to shadow or find rows by logical key is more valuable than insisting
+ * that every local row be well-formed.
+ */
+export function prepareUnvalidatedLocalRow({
+  listId,
+  item,
+  existingRowId,
+  updatedAt,
+}: {
+  listId: StaticListId;
+  item: unknown;
+  existingRowId: string | undefined;
+  updatedAt: number;
+}): { success: true; row: StoredLocalRow } | { success: false; error: string } {
+  try {
+    const sourceText = stringifyUnknownSource(item);
+
+    return {
+      success: true,
+      row: {
+        i: existingRowId ?? nanoid(),
+        u: isoDateTimeSchema.parse(updatedAt),
+        t: sourceText,
+        ...extractCachedIndexValuesFromSourceText(listId, sourceText),
+      },
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: getErrorMessage(error),
+    };
+  }
+}

--- a/src/entrypoints/background/@services/static-lists-service/summary-helpers.ts
+++ b/src/entrypoints/background/@services/static-lists-service/summary-helpers.ts
@@ -1,0 +1,62 @@
+import type { WritableDeep } from "type-fest";
+
+import type { StaticListMetadata } from "@/shared/@model/static-list-metadata";
+import type {
+  StaticListId,
+  StaticListSummary,
+} from "@/shared/@model/static-lists";
+
+import { getStaticListDefinitionInfo } from "./definition-helpers";
+import { interpretStoredRow } from "./interpretation";
+import type { StoredLocalRow, StoredRemoteRow } from "./types";
+
+export function createEmptySummary<ListId extends StaticListId>(
+  listId: ListId,
+): StaticListSummary<ListId> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the definition lookup is keyed by the same list id used to select the summary type
+  return getStaticListDefinitionInfo(
+    listId,
+  ).definition.createEmptySummary() as StaticListSummary<ListId>;
+}
+
+export function cloneEmptySummary<ListId extends StaticListId>(
+  listId: ListId,
+): WritableDeep<StaticListSummary<ListId>> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- structuredClone preserves the validated summary shape while WritableDeep models in-place adjustments
+  return structuredClone(createEmptySummary(listId)) as WritableDeep<
+    StaticListSummary<ListId>
+  >;
+}
+
+export function tryInterpretSummaryItemDelta<ListId extends StaticListId>(
+  listId: ListId,
+  mutableSummary: WritableDeep<StaticListSummary<ListId>>,
+  storedRow: StoredLocalRow | StoredRemoteRow,
+  origin: "remote" | "local" | "localOverride",
+  delta: 1 | -1,
+): void {
+  const interpretedRow = interpretStoredRow(listId, storedRow, origin);
+  if (!interpretedRow.interpretation.success) {
+    return;
+  }
+
+  getStaticListDefinitionInfo(listId).definition.adjustSummary(
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- definition selection and summary/item shapes are correlated by list id at runtime
+    mutableSummary as never,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- same list-specific correlation as above
+    interpretedRow.interpretation.item as never,
+    delta,
+  );
+}
+
+export function withUpdatedDerivedDataVersion<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+): StaticListMetadata<ListId> {
+  const definition = getStaticListDefinitionInfo(metadata.listId).definition;
+
+  return {
+    ...metadata,
+    physicalStorageVersion: definition.physicalStorageVersion,
+    derivedDataVersion: definition.derivedDataVersion,
+  };
+}

--- a/src/entrypoints/background/@services/static-lists-service/types.ts
+++ b/src/entrypoints/background/@services/static-lists-service/types.ts
@@ -1,0 +1,49 @@
+import type { JsonValue } from "type-fest";
+
+import type {
+  StaticListEntryInterpretation,
+  StaticListItemOrigin,
+} from "@/shared/@model/static-list-helpers";
+import type { IsoDateTime } from "@/shared/@primitives/temporal";
+
+export type StoredRowIndexSlotName = "p" | `s${number}`;
+
+export type StoredRowCachedIndexValues = Partial<
+  Record<StoredRowIndexSlotName, IDBValidKey | undefined>
+>;
+
+export type StoredRowBase = {
+  /** Raw JSONL source text, preserved verbatim for both remote and local rows. */
+  t: string;
+  /** Cached logical primary key extracted from the JSONL-form source, if any. */
+  p?: IDBValidKey | undefined;
+} & Partial<Record<`s${number}`, IDBValidKey | undefined>>;
+
+export type StoredRemoteRow = StoredRowBase & {
+  /** 1-based upstream JSONL line number, used as the physical remote row key. */
+  r: number;
+};
+
+export type StoredLocalRow = StoredRowBase & {
+  /** Stable local row id so malformed rows can still be edited or deleted precisely. */
+  i: string;
+  /** Last local write timestamp used for deterministic local ordering. */
+  u: IsoDateTime;
+};
+
+export type StoredRow = StoredRemoteRow | StoredLocalRow;
+
+export type InterpretedStoredRowResult = {
+  rowKey: string | number;
+  origin: StaticListItemOrigin;
+  sourceText: string;
+  sourceItem: JsonValue | undefined;
+  logicalPrimaryKey: IDBValidKey | undefined;
+  cachedIndexValues: StoredRowCachedIndexValues;
+  interpretation: StaticListEntryInterpretation;
+};
+
+export type { StaticListPageEntry } from "@/shared/@model/static-list-helpers";
+export type { StaticListPutLocalItemsOptions } from "@/shared/@model/static-list-helpers";
+export type { StaticListPutLocalItemsResult as LocalWriteResult } from "@/shared/@model/static-list-helpers";
+export type { StaticListRemoveLocalItemTarget as RemoveLocalItemTarget } from "@/shared/@model/static-list-helpers";

--- a/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
+++ b/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
@@ -1,6 +1,5 @@
 import { clamp, round } from "es-toolkit";
 import * as React from "react";
-import type { JsonValue } from "type-fest";
 
 import { useStaticListMetadata } from "@/shared/@ui-helpers/data-hooks";
 
@@ -18,18 +17,6 @@ const showIfEstimatedRemainingMoreThanMs = 2000;
 // Handles the case where loading sprints to a high percentage and then stalls.
 const showIfProgressStuckForMs = 2000;
 
-function extractItemCountFromRawSummary(
-  summary: JsonValue | undefined,
-): number {
-  if (summary && typeof summary === "object") {
-    const itemCount = "itemCount" in summary ? summary["itemCount"] : undefined;
-    if (itemCount && typeof itemCount === "number") {
-      return itemCount;
-    }
-  }
-  return 0;
-}
-
 export function ToastWithDataWarmup({ onDone }: { onDone: () => void }) {
   const accountsMetadata = useStaticListMetadata("accounts");
   const insertionsMetadata = useStaticListMetadata("insertions");
@@ -40,18 +27,22 @@ export function ToastWithDataWarmup({ onDone }: { onDone: () => void }) {
     insertionsMetadata.remoteActive &&
     tagsMetadata.remoteActive;
 
-  const nextExpectedItemCount =
-    (accountsMetadata.remoteNext?.upstreamInfo.itemCount ?? 0) +
-    (insertionsMetadata.remoteNext?.upstreamInfo.itemCount ?? 0) +
-    (tagsMetadata.remoteNext?.upstreamInfo.itemCount ?? 0);
+  const stagingExpectedItemCount =
+    (accountsMetadata.remoteStaging?.upstreamInfo.itemCount ?? 0) +
+    (insertionsMetadata.remoteStaging?.upstreamInfo.itemCount ?? 0) +
+    (tagsMetadata.remoteStaging?.upstreamInfo.itemCount ?? 0);
 
-  const nextItemCount =
-    extractItemCountFromRawSummary(accountsMetadata.remoteNext?.summary) +
-    extractItemCountFromRawSummary(insertionsMetadata.remoteNext?.summary) +
-    extractItemCountFromRawSummary(tagsMetadata.remoteNext?.summary);
+  const stagingItemCount =
+    (accountsMetadata.remoteStaging?.summary.itemCount ?? 0) +
+    (insertionsMetadata.remoteStaging?.summary.itemCount ?? 0) +
+    (tagsMetadata.remoteStaging?.summary.itemCount ?? 0);
 
-  const progressInPercentage = nextExpectedItemCount
-    ? clamp(round((nextItemCount / nextExpectedItemCount) * 100, 1), 0, 99.9)
+  const progressInPercentage = stagingExpectedItemCount
+    ? clamp(
+        round((stagingItemCount / stagingExpectedItemCount) * 100, 1),
+        0,
+        99.9,
+      )
     : 95;
 
   // Refs let the interval callback read the latest values without being

--- a/src/entrypoints/content/insertion-variants/shared/selector-resolution.ts
+++ b/src/entrypoints/content/insertion-variants/shared/selector-resolution.ts
@@ -131,7 +131,7 @@ function substituteInSelector(
 ): NormalizedSingleSelector {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- JSON roundtrip preserves shape
   return JSON.parse(
-    JSON.stringify(selector, (_key, value: unknown) =>
+    JSON.stringify(selector, (key, value: unknown) =>
       typeof value === "string" ? value.replaceAll("%", replacement) : value,
     ),
   );

--- a/src/entrypoints/popup/app/header.tsx
+++ b/src/entrypoints/popup/app/header.tsx
@@ -2,7 +2,6 @@ import { clamp } from "es-toolkit";
 import * as React from "react";
 
 import type { StaticListUpstreamInfo } from "@/shared/@model/static-list-helpers";
-import { staticListDefinitionLookup } from "@/shared/@model/static-lists";
 import {
   useStaticListMetadata,
   useStaticListsAutoUpdate,
@@ -13,45 +12,42 @@ import { formatDateTime } from "@/shared/formatting";
 function Percentage({
   extractFrom,
 }: {
-  extractFrom: { summary: unknown; upstreamInfo: StaticListUpstreamInfo };
+  extractFrom: {
+    summary: { itemCount: number };
+    upstreamInfo: StaticListUpstreamInfo;
+  };
 }) {
-  // TODO: Apply summary schema inside useStaticListMetadata
-  const summaryResult =
-    staticListDefinitionLookup.accounts.summarySchema.safeParse(
-      extractFrom.summary,
-    );
-
-  const loaded = summaryResult.data?.itemCount ?? 0;
+  const loaded = extractFrom.summary.itemCount;
   const total = extractFrom.upstreamInfo.itemCount;
+  const percentage =
+    total > 0 && Number.isFinite(total)
+      ? clamp(Math.round((loaded / total) * 100), 0, 99)
+      : 0;
 
-  return (
-    <span className="tabular-nums">
-      {clamp(Math.round((loaded / total) * 100), 0, 99)}%
-    </span>
-  );
+  return <span className="tabular-nums">{percentage}%</span>;
 }
 
 function AccountListMetadata() {
   const accountsMetadata = useStaticListMetadata("accounts");
 
   if (!accountsMetadata.remoteActive) {
-    if (!accountsMetadata.remoteNext) {
+    if (!accountsMetadata.remoteStaging) {
       return <>Список аккаунтов пока не начал загружаться</>;
     }
 
     return (
       <>
         Список аккаунтов обрабатывается:{" "}
-        <Percentage extractFrom={accountsMetadata.remoteNext} />
+        <Percentage extractFrom={accountsMetadata.remoteStaging} />
       </>
     );
   }
 
-  if (accountsMetadata.remoteNext) {
+  if (accountsMetadata.remoteStaging) {
     return (
       <>
         Список аккаунтов обновляется:{" "}
-        <Percentage extractFrom={accountsMetadata.remoteNext} />
+        <Percentage extractFrom={accountsMetadata.remoteStaging} />
       </>
     );
   }

--- a/src/entrypoints/popup/app/tabs/=config.tsx
+++ b/src/entrypoints/popup/app/tabs/=config.tsx
@@ -7,7 +7,7 @@ import {
   type TagId,
 } from "@/shared/@primitives/misc";
 import {
-  useRemoteNextStaticListSummary,
+  useRemoteStagingStaticListSummary,
   useStaticListItems,
   useStaticListSummary,
   useUserConfig,
@@ -135,7 +135,8 @@ export function ConfigTabBody() {
   const userConfig = useUserConfig();
   const tags = useStaticListItems("tags");
   const accountListSummary = useStaticListSummary("accounts");
-  const nextAccountListSummary = useRemoteNextStaticListSummary("accounts");
+  const stagingAccountListSummary =
+    useRemoteStagingStaticListSummary("accounts");
 
   const tagsToShow = tags.filter((tag) => tag.type === "accountCategory");
 
@@ -243,9 +244,9 @@ export function ConfigTabBody() {
                     ? accountListSummary.itemCountByTagId[tag.id]
                     : undefined
                 }
-                nextCount={
-                  nextAccountListSummary.itemCount > 0
-                    ? (nextAccountListSummary.itemCountByTagId[tag.id] ?? 0)
+                stagingCount={
+                  (stagingAccountListSummary?.itemCount ?? 0) > 0
+                    ? (stagingAccountListSummary?.itemCountByTagId[tag.id] ?? 0)
                     : undefined
                 }
               />

--- a/src/entrypoints/popup/app/tabs/=stats.tsx
+++ b/src/entrypoints/popup/app/tabs/=stats.tsx
@@ -1,6 +1,6 @@
 import {
   useFrontendBaseUrl,
-  useRemoteNextStaticListSummary,
+  useRemoteStagingStaticListSummary,
   useStaticListItems,
   useStaticListSummary,
 } from "@/shared/@ui-helpers/data-hooks";
@@ -42,13 +42,13 @@ function ListItem({
   count,
   href,
   name,
-  nextCount,
+  stagingCount,
 }: {
   color: string | undefined;
   count: number | undefined;
   href: string;
   name: string;
-  nextCount: number | undefined;
+  stagingCount: number | undefined;
 }) {
   return (
     <>
@@ -56,7 +56,7 @@ function ListItem({
         <UpdatableCount
           className="inline-block"
           count={count}
-          nextCount={nextCount}
+          stagingCount={stagingCount}
         />
       </div>
 
@@ -84,7 +84,8 @@ function ListItem({
 
 export function StatsTabBody() {
   const accountListSummary = useStaticListSummary("accounts");
-  const nextAccountListSummary = useRemoteNextStaticListSummary("accounts");
+  const stagingAccountListSummary =
+    useRemoteStagingStaticListSummary("accounts");
   const tags = useStaticListItems("tags");
   const frontendBaseUrl = useFrontendBaseUrl();
 
@@ -117,9 +118,9 @@ export function StatsTabBody() {
             href={generateUrl(frontendBaseUrl, `/region/${tag.id}`)}
             key={tag.id}
             name={tag.name}
-            nextCount={
-              nextAccountListSummary.itemCount > 0
-                ? (nextAccountListSummary.itemCountByTagId[tag.id] ?? 0)
+            stagingCount={
+              (stagingAccountListSummary?.itemCount ?? 0) > 0
+                ? (stagingAccountListSummary?.itemCountByTagId[tag.id] ?? 0)
                 : undefined
             }
           />
@@ -141,9 +142,9 @@ export function StatsTabBody() {
             )}
             key={tag.id}
             name={tag.name}
-            nextCount={
-              nextAccountListSummary.itemCount > 0
-                ? (nextAccountListSummary.itemCountByTagId[tag.id] ?? 0)
+            stagingCount={
+              (stagingAccountListSummary?.itemCount ?? 0) > 0
+                ? (stagingAccountListSummary?.itemCountByTagId[tag.id] ?? 0)
                 : undefined
             }
           />

--- a/src/entrypoints/popup/app/tabs/helpers.tsx
+++ b/src/entrypoints/popup/app/tabs/helpers.tsx
@@ -60,26 +60,26 @@ export function CollectingCommentsCheckbox() {
 export function UpdatableCount({
   className,
   count,
-  nextCount,
+  stagingCount,
 }: {
   className?: string | undefined;
   count: number | undefined;
-  nextCount: number | undefined;
+  stagingCount: number | undefined;
   wrapper?: undefined | "parentheses";
 }) {
-  if (count === undefined && nextCount === undefined) {
+  if (count === undefined && stagingCount === undefined) {
     return;
   }
 
   const formattedCount =
     typeof count === "number" ? formatInt(count) : undefined;
 
-  const formattedNextCount =
-    typeof nextCount === "number" ? formatInt(nextCount) : undefined;
+  const formattedStagingCount =
+    typeof stagingCount === "number" ? formatInt(stagingCount) : undefined;
 
-  const countToShow = formattedCount ?? formattedNextCount;
+  const countToShow = formattedCount ?? formattedStagingCount;
 
-  if (nextCount === undefined) {
+  if (stagingCount === undefined) {
     return <span className={cn("tabular-nums", className)}>{countToShow}</span>;
   }
   return (
@@ -90,7 +90,7 @@ export function UpdatableCount({
       <TooltipContent className="tabular-nums">
         {count === undefined
           ? "Данные обрабатываются"
-          : `Данные обновляются: ${formattedNextCount}`}
+          : `Данные обновляются: ${formattedStagingCount}`}
       </TooltipContent>
     </Tooltip>
   );

--- a/src/entrypoints/sidepanel/app/static-list-tab-body.tsx
+++ b/src/entrypoints/sidepanel/app/static-list-tab-body.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import type {
   StaticListCombiningMode,
-  StaticListItemOrigin,
+  StaticListPageEntry,
 } from "@/shared/@model/static-list-helpers";
 import {
   staticListDefinitionLookup,
@@ -50,12 +50,6 @@ const combiningModeOptions: Array<{
   { mode: "localOnly", label: "Local only" },
 ];
 
-export type PageItem = {
-  item: unknown;
-  origin: StaticListItemOrigin;
-  valid: boolean;
-};
-
 export function StaticListTabBody({ listId }: { listId: StaticListId }) {
   const [combiningMode, setCombiningMode] =
     React.useState<StaticListCombiningMode>("remoteOnly");
@@ -64,7 +58,7 @@ export function StaticListTabBody({ listId }: { listId: StaticListId }) {
     number | undefined
   >(undefined);
 
-  const [items, setItems] = React.useState<PageItem[]>([]);
+  const [items, setItems] = React.useState<StaticListPageEntry[]>([]);
   const [loading, setLoading] = React.useState(false);
   const [hasMore, setHasMore] = React.useState(true);
   const [editDialog, setEditDialog] = React.useState<
@@ -72,12 +66,15 @@ export function StaticListTabBody({ listId }: { listId: StaticListId }) {
   >(undefined);
 
   const listDefinition = staticListDefinitionLookup[listId];
-  const indexNames = listDefinition.indexes;
+  const indexNames = [
+    listDefinition.logicalPrimaryKey.name,
+    ...(listDefinition.secondaryIndexes ?? []).map((index) => index.name),
+  ];
 
   const loadPage = React.useCallback(
     async (offset: number) => {
       setLoading(true);
-      const result = await staticListsService.getItemsPage(listId, {
+      const result = await staticListsService.getEntriesPage(listId, {
         offset,
         limit: pageSize,
       });
@@ -128,16 +125,36 @@ export function StaticListTabBody({ listId }: { listId: StaticListId }) {
     void loadPage(items.length);
   }
 
-  function handleItemClick(pageItem: PageItem) {
-    if (pageItem.origin === "remote") {
-      setEditDialog({ type: "override", item: pageItem.item });
-    } else {
+  function handleItemClick(entry: StaticListPageEntry) {
+    if (entry.origin === "remote") {
+      if (entry.interpretation.success) {
+        setEditDialog({ type: "override", item: entry.interpretation.item });
+      } else {
+        setEditDialog({
+          type: "viewRaw",
+          origin: "remote",
+          sourceText: entry.sourceText,
+        });
+      }
+      return;
+    }
+
+    if (entry.interpretation.success) {
       setEditDialog({
         type: "edit",
-        item: pageItem.item,
-        origin: pageItem.origin,
+        item: entry.interpretation.item,
+        origin: entry.origin,
+        rowKey: String(entry.rowKey),
       });
+      return;
     }
+
+    setEditDialog({
+      type: "editRaw",
+      origin: entry.origin,
+      rowKey: String(entry.rowKey),
+      sourceText: entry.sourceText,
+    });
   }
 
   function handleDialogSaved() {

--- a/src/entrypoints/sidepanel/app/static-list-tab-body/actions-dropdown-menu.tsx
+++ b/src/entrypoints/sidepanel/app/static-list-tab-body/actions-dropdown-menu.tsx
@@ -7,12 +7,9 @@ import {
 
 import type {
   StaticListCombiningMode,
-  StaticListDefinition,
+  StaticListPageEntry,
 } from "@/shared/@model/static-list-helpers";
-import {
-  staticListDefinitionLookup,
-  type StaticListId,
-} from "@/shared/@model/static-lists";
+import type { StaticListId } from "@/shared/@model/static-lists";
 import { Button } from "@/shared/@ui-primitives/button";
 import {
   DropdownMenu,
@@ -26,52 +23,44 @@ import { staticListsService } from "@/shared/proxy-services";
 
 const exportPageSize = 10_000;
 
-async function fetchAllStoredItems(listId: StaticListId): Promise<unknown[]> {
-  const rawItems: unknown[] = [];
+async function fetchAllEntries(
+  listId: StaticListId,
+): Promise<StaticListPageEntry[]> {
+  const entries: StaticListPageEntry[] = [];
   let offset = 0;
   let hasMore = true;
 
   while (hasMore) {
-    const result = await staticListsService.getItemsPage(listId, {
+    const result = await staticListsService.getEntriesPage(listId, {
       offset,
       limit: exportPageSize,
     });
 
-    for (const pageItem of result.items) {
-      rawItems.push(pageItem.item);
-    }
+    entries.push(...result.items);
     offset += result.items.length;
     hasMore = offset < result.totalCount;
   }
 
-  return rawItems;
+  return entries;
 }
 
 async function handleCopyAsJson(listId: StaticListId) {
-  const rawItems = await fetchAllStoredItems(listId);
-  const text = JSON.stringify(rawItems, undefined, 2);
+  const entries = await fetchAllEntries(listId);
+  const text = JSON.stringify(
+    entries.flatMap((entry) =>
+      entry.interpretation.success ? [entry.interpretation.item] : [],
+    ),
+    undefined,
+    2,
+  );
   await navigator.clipboard.writeText(text);
 }
 
 async function handleCopyAsJsonl(listId: StaticListId) {
-  const rawItems = await fetchAllStoredItems(listId);
-
-  const definition: StaticListDefinition = staticListDefinitionLookup[listId];
-
+  const entries = await fetchAllEntries(listId);
   const text =
-    rawItems
-      .map((rawItem) => {
-        const item = definition.storedItemSchema.safeParse(rawItem);
-
-        return item.success
-          ? definition.mapStoredToReceived(item.data)
-          : undefined;
-      })
-      .filter((item) => item !== undefined)
-      .map(
-        (item) => definition.jsonlStringifyRow?.(item) ?? JSON.stringify(item),
-      )
-      .join("\n") + (rawItems.length > 0 ? "\n" : "");
+    entries.map((entry) => entry.sourceText).join("\n") +
+    (entries.length > 0 ? "\n" : "");
   await navigator.clipboard.writeText(text);
 }
 

--- a/src/entrypoints/sidepanel/app/static-list-tab-body/item-edit-dialog.tsx
+++ b/src/entrypoints/sidepanel/app/static-list-tab-body/item-edit-dialog.tsx
@@ -26,8 +26,20 @@ import { parsePastedContent } from "./item-edit-dialog/parse-pasted-content";
 
 export type ItemEditDialogMode =
   | { type: "add" }
-  | { type: "edit"; item: unknown; origin: StaticListItemOrigin }
-  | { type: "override"; item: unknown };
+  | {
+      type: "edit";
+      item: unknown;
+      origin: StaticListItemOrigin;
+      rowKey: string;
+    }
+  | {
+      type: "editRaw";
+      origin: Exclude<StaticListItemOrigin, "remote">;
+      rowKey: string;
+      sourceText: string;
+    }
+  | { type: "override"; item: unknown }
+  | { type: "viewRaw"; origin: "remote"; sourceText: string };
 
 export function ItemEditDialog({
   combiningMode,
@@ -43,38 +55,72 @@ export function ItemEditDialog({
   onSaved: () => void;
 }) {
   const listDefinition = staticListDefinitionLookup[listId];
-  const firstIndex = listDefinition.indexes[0];
-
   const initialJson =
-    mode.type === "add" ? "" : JSON.stringify(mode.item, undefined, 2);
+    mode.type === "add"
+      ? ""
+      : mode.type === "editRaw" || mode.type === "viewRaw"
+        ? mode.sourceText
+        : JSON.stringify(mode.item, undefined, 2);
 
   const [json, setJson] = React.useState(initialJson);
+  const [addMode, setAddMode] = React.useState<"typed" | "raw">("typed");
   const [error, setError] = React.useState<string | undefined>(undefined);
   const [saving, setSaving] = React.useState(false);
 
   const title =
     mode.type === "add"
       ? "Новая локальная запись"
-      : mode.type === "override"
-        ? "Запись с сервера"
-        : "Локальная запись";
+      : mode.type === "viewRaw"
+        ? "Невалидная запись с сервера"
+        : mode.type === "editRaw"
+          ? "Невалидная локальная запись"
+          : mode.type === "override"
+            ? "Запись с сервера"
+            : "Локальная запись";
+
+  const localRowKey =
+    mode.type === "edit" || mode.type === "editRaw" ? mode.rowKey : undefined;
 
   async function handleSave() {
     setError(undefined);
 
     if (mode.type === "add") {
-      const result = parsePastedContent(json, listDefinition);
-      if (!result.success) {
-        setError(result.error);
-        return;
-      }
       setSaving(true);
       try {
-        await Promise.all(
-          result.storedItems.map((item) =>
-            staticListsService.putLocalItem(listId, item),
-          ),
-        );
+        if (addMode === "typed") {
+          const result = parsePastedContent(json, listDefinition);
+          if (!result.success) {
+            setError(result.error);
+            setSaving(false);
+            return;
+          }
+
+          const saveResult = await staticListsService.putLocalItems(
+            listId,
+            result.interpretedItems,
+            { validate: true },
+          );
+          if (!saveResult.success) {
+            setError(saveResult.error);
+            setSaving(false);
+            return;
+          }
+        } else {
+          const lines = json
+            .split("\n")
+            .map((line) => line.trimEnd())
+            .filter((line) => line.trim() !== "");
+          const saveResult = await staticListsService.putLocalItems(
+            listId,
+            lines,
+            { validate: false },
+          );
+          if (!saveResult.success) {
+            setError(saveResult.error);
+            setSaving(false);
+            return;
+          }
+        }
         onSaved();
       } catch (saveError: unknown) {
         setError(
@@ -82,6 +128,32 @@ export function ItemEditDialog({
         );
         setSaving(false);
       }
+      return;
+    }
+
+    if (mode.type === "editRaw") {
+      setSaving(true);
+      try {
+        const saveResult = await staticListsService.putLocalItem(listId, json, {
+          rowKey: mode.rowKey,
+          validate: false,
+        });
+        if (!saveResult.success) {
+          setError(saveResult.error);
+          setSaving(false);
+          return;
+        }
+        onSaved();
+      } catch (saveError: unknown) {
+        setError(
+          saveError instanceof Error ? saveError.message : "Ошибка сохранения",
+        );
+        setSaving(false);
+      }
+      return;
+    }
+
+    if (mode.type === "viewRaw") {
       return;
     }
 
@@ -94,7 +166,7 @@ export function ItemEditDialog({
       return;
     }
 
-    const validation = listDefinition.storedItemSchema.safeParse(parsed);
+    const validation = listDefinition.interpretedItemSchema.safeParse(parsed);
     if (!validation.success) {
       setError(
         validation.error.issues
@@ -108,7 +180,19 @@ export function ItemEditDialog({
 
     setSaving(true);
     try {
-      await staticListsService.putLocalItem(listId, validation.data);
+      const saveResult = await staticListsService.putLocalItem(
+        listId,
+        validation.data,
+        {
+          validate: true,
+          ...(mode.type === "edit" ? { rowKey: mode.rowKey } : {}),
+        },
+      );
+      if (!saveResult.success) {
+        setError(saveResult.error);
+        setSaving(false);
+        return;
+      }
       onSaved();
     } catch (saveError: unknown) {
       setError(
@@ -119,26 +203,13 @@ export function ItemEditDialog({
   }
 
   async function handleDelete() {
-    if (mode.type === "add") {
+    if (localRowKey === undefined) {
       return;
     }
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- item is always a record from Dexie
-    const itemRecord = mode.item as Record<string, unknown>;
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- firstIndex is always a string key
-    const firstIndexKey = firstIndex as string;
-
     setSaving(true);
     try {
-      /* eslint-disable @typescript-eslint/consistent-type-assertions -- generic Index cannot be inferred from union StaticListId; runtime values are correct */
-      await (
-        staticListsService.removeLocalItem as (
-          listId: StaticListId,
-          index: string,
-          value: unknown,
-        ) => Promise<{ deletedCount: number }>
-      )(listId, firstIndexKey, itemRecord[firstIndexKey]);
-      /* eslint-enable @typescript-eslint/consistent-type-assertions -- re-enable after block above */
+      await staticListsService.removeLocalItem(listId, { rowKey: localRowKey });
       onSaved();
     } catch (deleteError: unknown) {
       setError(
@@ -149,7 +220,7 @@ export function ItemEditDialog({
   }
 
   const canDelete =
-    mode.type === "edit" &&
+    (mode.type === "edit" || mode.type === "editRaw") &&
     (mode.origin === "local" || mode.origin === "localOverride");
 
   return (
@@ -170,9 +241,12 @@ export function ItemEditDialog({
           className="flex-1 font-mono text-xs"
           placeholder={
             mode.type === "add"
-              ? "JSON, JSONL или содержимое .ts файла"
+              ? addMode === "typed"
+                ? "JSON, JSONL или содержимое .ts файла"
+                : "Одна сырая JSONL-строка на запись"
               : undefined
           }
+          readOnly={mode.type === "viewRaw"}
           value={json}
           onChange={(event) => {
             setJson(event.target.value);
@@ -181,6 +255,31 @@ export function ItemEditDialog({
             }
           }}
         />
+
+        {mode.type === "add" && (
+          <div className="flex gap-2 text-sm">
+            <Button
+              onClick={() => {
+                setAddMode("typed");
+                setError(undefined);
+              }}
+              size="sm"
+              variant={addMode === "typed" ? "default" : "outline"}
+            >
+              Typed import
+            </Button>
+            <Button
+              onClick={() => {
+                setAddMode("raw");
+                setError(undefined);
+              }}
+              size="sm"
+              variant={addMode === "raw" ? "default" : "outline"}
+            >
+              Raw import
+            </Button>
+          </div>
+        )}
 
         {error && (
           <FieldError className="whitespace-pre-wrap">{error}</FieldError>
@@ -204,7 +303,7 @@ export function ItemEditDialog({
             </Button>
           )}
           <div className="-my-1 flex-1" />
-          {combiningMode === "remoteOnly" ? (
+          {combiningMode === "remoteOnly" || mode.type === "viewRaw" ? (
             <>
               <DialogClose render={<Button size="sm" variant="outline" />}>
                 Закрыть
@@ -224,9 +323,11 @@ export function ItemEditDialog({
                   ? "Сохранение..."
                   : mode.type === "override"
                     ? "Перезаписать локально"
-                    : mode.type === "edit"
-                      ? "Сохранить локально"
-                      : "Добавить локально"}
+                    : mode.type === "editRaw"
+                      ? "Сохранить raw"
+                      : mode.type === "edit"
+                        ? "Сохранить локально"
+                        : "Добавить локально"}
               </Button>
             </>
           )}

--- a/src/entrypoints/sidepanel/app/static-list-tab-body/item-edit-dialog/parse-pasted-content.ts
+++ b/src/entrypoints/sidepanel/app/static-list-tab-body/item-edit-dialog/parse-pasted-content.ts
@@ -3,13 +3,10 @@ import type { z } from "zod/mini";
 
 import { extractCuratedListFromTs } from "@/shared/@model/static-list-extraction";
 import type { StaticListDefinition } from "@/shared/@model/static-list-helpers";
-import type {
-  StaticListId,
-  StaticListItem,
-} from "@/shared/@model/static-lists";
+import type { StaticListItem } from "@/shared/@model/static-lists";
 
 export type ParseResult =
-  | { success: true; storedItems: Array<StaticListItem<StaticListId>> }
+  | { success: true; interpretedItems: StaticListItem[] }
   | { success: false; error: string };
 
 export function parsePastedContent(
@@ -24,7 +21,7 @@ export function parsePastedContent(
   // Attempt TypeScript array extraction first (handles full .ts file paste)
   const extractedItems = extractCuratedListFromTs(trimmed);
 
-  // Try as single JSON (array of stored items, same as "Copy as JSON")
+  // Try as single JSON (array of interpreted items, same as "Copy as JSON")
   let parsed: unknown = extractedItems;
   if (!parsed) {
     try {
@@ -36,13 +33,13 @@ export function parsePastedContent(
   }
 
   if (parsed) {
-    const storedItems: Array<StaticListItem<StaticListId>> = [];
+    const interpretedItems: StaticListItem[] = [];
     const parsedItems = Array.isArray(parsed) ? parsed : [parsed];
     for (const [i, item] of parsedItems.entries()) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- type-casting is needed because we deal with a generic list
-      const result = definition.storedItemSchema.safeParse(
+      const result = definition.interpretedItemSchema.safeParse(
         item,
-      ) as z.util.SafeParseResult<StaticListItem<StaticListId>>;
+      ) as z.util.SafeParseResult<StaticListItem>;
 
       if (!result.success) {
         const messages = result.error.issues
@@ -55,16 +52,16 @@ export function parsePastedContent(
           error: `Элемент ${i + 1}: ${messages}`,
         };
       }
-      storedItems.push(result.data);
+      interpretedItems.push(result.data);
     }
-    if (storedItems.length > 0) {
-      return { success: true, storedItems };
+    if (interpretedItems.length > 0) {
+      return { success: true, interpretedItems };
     }
   }
 
-  // JSONL: one JSON value per line (received format), empty lines ignored
+  // JSONL: one JSON value per line (JSONL format), empty lines ignored
   const lines = trimmed.split("\n");
-  const storedItems: Array<StaticListItem<StaticListId>> = [];
+  const interpretedItems: StaticListItem[] = [];
   for (const [i, line] of lines.entries()) {
     if (line.trim() === "") {
       continue;
@@ -79,9 +76,9 @@ export function parsePastedContent(
         error: `Строка ${i + 1}: невалидный JSON`,
       };
     }
-    const receivedResult = definition.receivedItemSchema.safeParse(lineParsed);
-    if (!receivedResult.success) {
-      const messages = receivedResult.error.issues
+    const jsonlItemResult = definition.jsonlItemSchema.safeParse(lineParsed);
+    if (!jsonlItemResult.success) {
+      const messages = jsonlItemResult.error.issues
         .map((issue) => `${issue.path.map(String).join(".")}: ${issue.message}`)
         .join("; ");
       return {
@@ -89,22 +86,14 @@ export function parsePastedContent(
         error: `Строка ${i + 1}: ${messages}`,
       };
     }
-    try {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- type-casting is needed because we deal with a generic list
-      const stored = definition.mapReceivedToStored(
-        receivedResult.data,
-      ) as StaticListItem<StaticListId>;
 
-      storedItems.push(stored);
-    } catch (mapError) {
-      const message =
-        mapError instanceof Error ? mapError.message : String(mapError);
-      return {
-        success: false,
-        error: `Строка ${i + 1}: ${message}`,
-      };
-    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- type-casting is needed because we deal with a generic list
+    const interpretedItem = definition.interpretJsonlItem(
+      jsonlItemResult.data,
+    ) as StaticListItem;
+
+    interpretedItems.push(interpretedItem);
   }
 
-  return { success: true, storedItems };
+  return { success: true, interpretedItems };
 }

--- a/src/entrypoints/sidepanel/app/static-list-tab-body/item-row.tsx
+++ b/src/entrypoints/sidepanel/app/static-list-tab-body/item-row.tsx
@@ -1,7 +1,8 @@
-import type { StaticListItemOrigin } from "@/shared/@model/static-list-helpers";
+import type {
+  StaticListItemOrigin,
+  StaticListPageEntry,
+} from "@/shared/@model/static-list-helpers";
 import { cn } from "@/shared/tailwindcss-helpers";
-
-import type { PageItem } from "../static-list-tab-body";
 
 const originDefinitionLookup: Record<
   StaticListItemOrigin,
@@ -47,11 +48,14 @@ export function ItemRow({
   onClick,
 }: {
   indexNames: readonly string[];
-  item: PageItem;
+  item: StaticListPageEntry;
   onClick: () => void;
 }) {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- item is always a record from Dexie
-  const itemRecord = pageItem.item as Record<string, unknown>;
+  function getIndexValue(indexPosition: number): unknown {
+    const slotName: "p" | `s${number}` =
+      indexPosition === 0 ? "p" : `s${indexPosition}`;
+    return pageItem.indexValues[slotName];
+  }
 
   return (
     <button
@@ -61,7 +65,7 @@ export function ItemRow({
           text-xs transition-colors
           hover:bg-accent/50
         `,
-        !pageItem.valid && "bg-destructive/10",
+        !pageItem.interpretation.success && "bg-destructive/10",
       )}
       onClick={onClick}
       style={{
@@ -79,9 +83,9 @@ export function ItemRow({
           {originDefinitionLookup[pageItem.origin].label}
         </span>
       </div>
-      {indexNames.map((indexName) => (
+      {indexNames.map((indexName, indexPosition) => (
         <div className="truncate" key={indexName}>
-          {formatCellValue(itemRecord[indexName])}
+          {formatCellValue(getIndexValue(indexPosition))}
         </div>
       ))}
     </button>

--- a/src/shared/@model/static-list-helpers.ts
+++ b/src/shared/@model/static-list-helpers.ts
@@ -1,10 +1,23 @@
 import type { WritableDeep } from "type-fest";
 import { z } from "zod/mini";
 
-import { itemCountSchema } from "../@primitives/misc";
+import { itemCountSchema, tagIdSchema } from "../@primitives/misc";
 import { isoDateTimeSchema } from "../@primitives/temporal";
 
-export const receivedTagIdSchema = z.union([z.number(), z.string()]);
+export const receivedTagIdSchema = z.union([
+  z.number().check(z.int(), z.nonnegative()),
+  tagIdSchema,
+]);
+export type ReceivedTagId = z.infer<typeof receivedTagIdSchema>;
+
+export function stringifyReceivedTagId(
+  receivedTagId: ReceivedTagId,
+): z.infer<typeof tagIdSchema> {
+  // The schema already guarantees the JSONL-form value normalizes to a valid
+  // tag ID string, so interpretation can remap without new validation.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- schema guarantees the normalized string satisfies tagIdSchema
+  return String(receivedTagId) as z.infer<typeof tagIdSchema>;
+}
 
 export const staticListUpstreamInfoSchema = z.readonly(
   z.object({
@@ -37,42 +50,163 @@ export const staticListItemOriginSchema = z.enum([
 ]);
 export type StaticListItemOrigin = z.infer<typeof staticListItemOriginSchema>;
 
+/**
+ * Interpretation failures stop at the raw JSONL boundary on purpose.
+ *
+ * Remote rows are persisted even when they are malformed, so reads need to tell
+ * the difference between "the source was not JSON at all" and "it was JSON but
+ * no longer matches the list's JSONL contract". Anything beyond that belongs in
+ * `interpretJsonlItem`, which is expected to stay total once schema validation
+ * has passed.
+ */
+export type StaticListEntryInterpretation =
+  | { success: true; item: unknown }
+  | { success: false; kind: "jsonParse" | "jsonlSchema"; error: string };
+
+/**
+ * This is intentionally a lossless UI/debug view of stored rows rather than a
+ * business-domain API.
+ *
+ * It keeps enough source and merge information to inspect malformed rows,
+ * shadowing, and duplicate logical keys without forcing the sidepanel to infer
+ * storage behavior from typed business reads.
+ */
+export type StaticListPageEntry = {
+  rowKey: string | number;
+  origin: StaticListItemOrigin;
+  logicalPrimaryKey: IDBValidKey | undefined;
+  indexValues: Partial<Record<"p" | `s${number}`, IDBValidKey | undefined>>;
+  sourceText: string;
+  sourceItem: unknown;
+  interpretation: StaticListEntryInterpretation;
+  shadowedRemoteRowKeys: IDBValidKey[];
+};
+
+export type StaticListPutLocalItemsResult =
+  | { success: true }
+  | {
+      success: false;
+      error: string;
+      details?: unknown;
+      limit?: number;
+      attempting?: number;
+    };
+
+/**
+ * `rowKey` is the exact-edit escape hatch for local rows.
+ *
+ * Normal writes are logical-key upserts because that is the cheapest way to
+ * express overrides. Once a user opens a concrete local row, though, edits must
+ * be able to target that physical row even if it was malformed or if its
+ * logical key changes during editing.
+ */
+export type StaticListPutLocalItemsOptions = {
+  validate?: boolean;
+  rowKey?: string;
+};
+
+export type StaticListRemoveLocalItemTarget =
+  | { logicalPrimaryKey: IDBValidKey; rowKey?: never }
+  | { rowKey: string; logicalPrimaryKey?: never };
+
+export type StaticListIndexDefinition<
+  JsonlItem,
+  InterpretedKeyName extends string = string,
+> = {
+  name: InterpretedKeyName;
+  extractFromJsonlItem: {
+    bivarianceHack(jsonlItem: JsonlItem): IDBValidKey | undefined;
+  }["bivarianceHack"];
+};
+
+type StaticListMapper<Input, Output> = {
+  bivarianceHack(input: Input): Output;
+}["bivarianceHack"];
+
+type StaticListAdjustSummary<Summary, Item> = {
+  bivarianceHack(
+    mutableSummary: WritableDeep<Summary>,
+    item: Item,
+    delta: 1 | -1,
+  ): void;
+}["bivarianceHack"];
+
+/**
+ * Static list definitions describe three separate contracts:
+ *
+ * 1. the upstream JSONL shape we preserve in storage
+ * 2. the interpreted runtime shape the app consumes
+ * 3. the persisted version boundaries that decide whether we can keep local
+ *    data, remote data, or neither
+ *
+ * That separation is what lets us re-interpret old remote rows after an app
+ * upgrade without making storage depend on whichever extension version first
+ * downloaded them.
+ */
 export type StaticListDefinition<
-  ReceivedItemSchema extends z.ZodMiniType = z.ZodMiniType,
-  StoredItemSchema extends z.ZodMiniType = z.ZodMiniType,
+  JsonlItemSchema extends z.ZodMiniType = z.ZodMiniType,
+  InterpretedItemSchema extends z.ZodMiniType = z.ZodMiniType,
   SummarySchema extends z.ZodMiniType<{ itemCount: number }> = z.ZodMiniType<{
     itemCount: number;
   }>,
+  InterpretedKeyName extends string = string,
 > = {
   dxSidepanelTab?: { label: string };
-  receivedItemSchema: ReceivedItemSchema;
-  storedItemSchema: StoredItemSchema;
-  mapReceivedToStored: (
-    receivedItem: z.infer<ReceivedItemSchema>,
-  ) => z.infer<StoredItemSchema>;
-
-  mapStoredToReceived: (
-    storedItem: z.infer<StoredItemSchema>,
-  ) => z.infer<ReceivedItemSchema>;
-
-  jsonlRowSortingBy?: Array<keyof z.infer<StoredItemSchema>>;
-  jsonlStringifyRow?: (item: z.infer<ReceivedItemSchema>) => string;
-
-  indexes: [
-    keyof z.infer<StoredItemSchema>,
-    ...Array<keyof z.infer<StoredItemSchema>>,
-  ];
+  /** Bump only when the IndexedDB layout itself becomes incompatible. */
+  physicalStorageVersion: number;
+  /** Bump when persisted remote-derived data semantics change and a redownload is cheaper than rebuilding. */
+  derivedDataVersion: string;
+  jsonlItemSchema: JsonlItemSchema;
+  interpretedItemSchema: InterpretedItemSchema;
+  /** Merging and shadowing are defined only by this key, never by secondary indexes. */
+  logicalPrimaryKey: StaticListIndexDefinition<
+    z.infer<JsonlItemSchema>,
+    InterpretedKeyName
+  >;
+  /** Secondary indexes exist for lookups only; they must not affect merge precedence. */
+  secondaryIndexes?: Array<
+    StaticListIndexDefinition<z.infer<JsonlItemSchema>, InterpretedKeyName>
+  >;
+  interpretJsonlItem: StaticListMapper<
+    z.infer<JsonlItemSchema>,
+    z.infer<InterpretedItemSchema>
+  >;
+  serializeInterpretedItemAsJsonl: StaticListMapper<
+    z.infer<InterpretedItemSchema>,
+    z.infer<JsonlItemSchema>
+  >;
+  jsonlExportSortingBy?: InterpretedKeyName[];
+  jsonlStringifyRow?: StaticListMapper<z.infer<JsonlItemSchema>, string>;
 
   summarySchema: SummarySchema;
   createEmptySummary: () => z.infer<SummarySchema>;
-
-  mutateSummary: (
-    mutableSummary: WritableDeep<z.infer<SummarySchema>>,
-    item: z.infer<StoredItemSchema>,
-  ) => void;
-
-  unmutateSummary: (
-    mutableSummary: WritableDeep<z.infer<SummarySchema>>,
-    item: z.infer<StoredItemSchema>,
-  ) => void;
+  adjustSummary: StaticListAdjustSummary<
+    z.infer<SummarySchema>,
+    z.infer<InterpretedItemSchema>
+  >;
+  localRowLimit?: number;
 };
+
+export function defineStaticListDefinition<
+  JsonlItemSchema extends z.ZodMiniType,
+  InterpretedItemSchema extends z.ZodMiniType,
+  SummarySchema extends z.ZodMiniType<{ itemCount: number }>,
+  InterpretedKeyName extends Extract<
+    keyof z.infer<InterpretedItemSchema>,
+    string
+  >,
+>(
+  definition: StaticListDefinition<
+    JsonlItemSchema,
+    InterpretedItemSchema,
+    SummarySchema,
+    InterpretedKeyName
+  >,
+): StaticListDefinition<
+  JsonlItemSchema,
+  InterpretedItemSchema,
+  SummarySchema,
+  InterpretedKeyName
+> {
+  return definition;
+}

--- a/src/shared/@model/static-list-metadata.ts
+++ b/src/shared/@model/static-list-metadata.ts
@@ -6,13 +6,26 @@ import {
   staticListRemoteInstanceSchema,
   staticListUpstreamInfoSchema,
 } from "./static-list-helpers";
-import { staticListIds } from "./static-lists";
+import {
+  type StaticListId,
+  staticListIds,
+  type StaticListSummary,
+} from "./static-lists";
 
+/**
+ * Persist only the state that cannot be reproduced cheaply.
+ *
+ * Remote summaries live here because they are built during download and keep
+ * `remoteOnly` reads fast after restart. Local and combined summaries stay out
+ * of storage on purpose: they are dev-only derived views and are recomputed in
+ * memory when needed.
+ */
 export const staticListMetadataSchema = z.readonly(
   z.object({
     listId: z.enum(staticListIds),
+    physicalStorageVersion: z.number().check(z.int(), z.nonnegative()),
+    derivedDataVersion: z.string(),
     combiningMode: staticListCombiningModeSchema,
-    combinedSummary: z.exactOptional(z.json()),
     remoteActiveInstance: staticListRemoteInstanceSchema,
     remoteActive: z.exactOptional(
       z.readonly(
@@ -24,10 +37,9 @@ export const staticListMetadataSchema = z.readonly(
         }),
       ),
     ),
-    remoteNext: z.exactOptional(
+    remoteStaging: z.exactOptional(
       z.readonly(
         z.object({
-          lockId: z.string(),
           startedAt: isoDateTimeSchema,
           summary: z.json(),
           updatedAt: isoDateTimeSchema,
@@ -35,8 +47,35 @@ export const staticListMetadataSchema = z.readonly(
         }),
       ),
     ),
-    localSummary: z.exactOptional(z.json()),
     localUpdatedAt: z.exactOptional(isoDateTimeSchema),
   }),
 );
-export type StaticListMetadata = z.infer<typeof staticListMetadataSchema>;
+export type StoredStaticListMetadata = z.infer<typeof staticListMetadataSchema>;
+
+type StoredStaticListMetadataRemoteState = NonNullable<
+  StoredStaticListMetadata["remoteActive"]
+>;
+
+type StaticListMetadataRemoteState<ListId extends StaticListId> = Readonly<
+  Omit<StoredStaticListMetadataRemoteState, "summary"> & {
+    summary: StaticListSummary<ListId>;
+  }
+>;
+
+type StaticListMetadataBase = Omit<
+  StoredStaticListMetadata,
+  "listId" | "remoteActive" | "remoteStaging"
+>;
+
+type StaticListMetadataByListId = {
+  [ListId in StaticListId]: Readonly<
+    StaticListMetadataBase & {
+      listId: ListId;
+      remoteActive?: StaticListMetadataRemoteState<ListId>;
+      remoteStaging?: StaticListMetadataRemoteState<ListId>;
+    }
+  >;
+};
+
+export type StaticListMetadata<ListId extends StaticListId = StaticListId> =
+  ListId extends StaticListId ? StaticListMetadataByListId[ListId] : never;

--- a/src/shared/@model/static-lists.ts
+++ b/src/shared/@model/static-lists.ts
@@ -1,6 +1,6 @@
+import type { JsonValue } from "type-fest";
 import type { z } from "zod/mini";
 
-import type { StaticListDefinition } from "./static-list-helpers";
 import { accountListDefinition } from "./static-lists/=accounts";
 import { announcementListDefinition } from "./static-lists/=announcements";
 import { insertionListDefinition } from "./static-lists/=insertions";
@@ -13,26 +13,38 @@ export const staticListDefinitionLookup = {
   insertions: insertionListDefinition,
   tags: tagListDefinition,
   walls: wallListDefinition,
-} satisfies Record<string, StaticListDefinition>;
+};
 
 export type StaticListId = keyof typeof staticListDefinitionLookup;
+type StaticListDefinitionLookup = typeof staticListDefinitionLookup;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Object.keys returns a string array (limitation of TS)
 export const staticListIds = Object.keys(
   staticListDefinitionLookup,
 ) as StaticListId[];
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Object.entries returns a string in tuple key (limitation of TS)
-export const staticListDefinitionEntries = Object.entries(
-  staticListDefinitionLookup,
-) as Array<[StaticListId, StaticListDefinition]>;
+type StaticListItemByListId = {
+  [ListId in StaticListId]: StaticListDefinitionLookup[ListId] extends {
+    interpretedItemSchema: infer InterpretedItemSchema extends
+      z.ZodMiniType<JsonValue>;
+  }
+    ? z.infer<InterpretedItemSchema>
+    : never;
+};
 
-export type StaticListItem<ListId extends StaticListId> = z.infer<
-  (typeof staticListDefinitionLookup)[ListId]["storedItemSchema"]
->;
+type StaticListSummaryByListId = {
+  [ListId in StaticListId]: StaticListDefinitionLookup[ListId] extends {
+    summarySchema: infer SummarySchema extends z.ZodMiniType<JsonValue>;
+  }
+    ? z.infer<SummarySchema>
+    : never;
+};
+
+export type StaticListItem<ListId extends StaticListId = StaticListId> =
+  ListId extends StaticListId ? StaticListItemByListId[ListId] : never;
 
 export type StaticListSummary<ListId extends StaticListId = StaticListId> =
-  z.infer<(typeof staticListDefinitionLookup)[ListId]["summarySchema"]>;
+  ListId extends StaticListId ? StaticListSummaryByListId[ListId] : never;
 
 export type { AccountListItem } from "./static-lists/=accounts";
 export type { AnnouncementListItem } from "./static-lists/=announcements";

--- a/src/shared/@model/static-lists/=accounts.ts
+++ b/src/shared/@model/static-lists/=accounts.ts
@@ -4,11 +4,13 @@ import { itemCountSchema, tagIdSchema } from "../../@primitives/misc";
 import { vkIdSchema, vkNicknameSchema } from "../../@primitives/vk";
 import { omitUndefined } from "../../omit-undefined";
 import {
+  defineStaticListDefinition,
   receivedTagIdSchema,
   type StaticListDefinition,
+  stringifyReceivedTagId,
 } from "../static-list-helpers";
 
-const receivedAccountListItemSchema = z.readonly(
+const jsonlAccountListItemSchema = z.readonly(
   z.tuple([
     vkIdSchema,
     z // tagIds
@@ -20,7 +22,7 @@ const receivedAccountListItemSchema = z.readonly(
   ]),
 );
 
-const storedAccountListItemSchema = z.readonly(
+const interpretedAccountListItemSchema = z.readonly(
   z.object({
     vkId: vkIdSchema,
     vkNickname: z.exactOptional(vkNicknameSchema),
@@ -28,7 +30,7 @@ const storedAccountListItemSchema = z.readonly(
   }),
 );
 /** @public */
-export type AccountListItem = z.infer<typeof storedAccountListItemSchema>;
+export type AccountListItem = z.infer<typeof interpretedAccountListItemSchema>;
 
 const accountListSummarySchema = z.readonly(
   z.object({
@@ -38,44 +40,47 @@ const accountListSummarySchema = z.readonly(
 );
 
 export const accountListDefinition: StaticListDefinition<
-  typeof receivedAccountListItemSchema,
-  typeof storedAccountListItemSchema,
+  typeof jsonlAccountListItemSchema,
+  typeof interpretedAccountListItemSchema,
   typeof accountListSummarySchema
-> = {
-  receivedItemSchema: receivedAccountListItemSchema,
-  storedItemSchema: storedAccountListItemSchema,
-  mapReceivedToStored: ([vkId, rawTagIds, vkNickname]) =>
+> = defineStaticListDefinition({
+  physicalStorageVersion: 1,
+  derivedDataVersion: "20260321",
+  jsonlItemSchema: jsonlAccountListItemSchema,
+  interpretedItemSchema: interpretedAccountListItemSchema,
+  logicalPrimaryKey: {
+    name: "vkId",
+    extractFromJsonlItem: ([vkId]) => vkId,
+  },
+  secondaryIndexes: [
+    {
+      name: "vkNickname",
+      extractFromJsonlItem: (jsonlItem) => jsonlItem[2],
+    },
+  ],
+  interpretJsonlItem: ([vkId, rawTagIds, vkNickname]) =>
     omitUndefined({
       vkId,
       vkNickname,
       tagIds:
         typeof rawTagIds === "string" || typeof rawTagIds === "number"
-          ? [tagIdSchema.parse(String(rawTagIds))]
-          : rawTagIds.map((rawTagId) => tagIdSchema.parse(String(rawTagId))),
+          ? [stringifyReceivedTagId(rawTagIds)]
+          : rawTagIds.map((rawTagId) => stringifyReceivedTagId(rawTagId)),
     }),
 
-  mapStoredToReceived: ({ vkId, tagIds, vkNickname }) =>
+  serializeInterpretedItemAsJsonl: ({ vkId, tagIds, vkNickname }) =>
     vkNickname ? [vkId, tagIds, vkNickname] : [vkId, tagIds],
-
-  indexes: ["vkId", "vkNickname"],
 
   summarySchema: accountListSummarySchema,
   createEmptySummary: () => ({
     itemCount: 0,
     itemCountByTagId: {},
   }),
-  mutateSummary: (mutableSummary, item) => {
-    mutableSummary.itemCount += 1;
+  adjustSummary: (mutableSummary, item, delta) => {
+    mutableSummary.itemCount += delta;
     for (const tagId of item.tagIds) {
       mutableSummary.itemCountByTagId[tagId] =
-        (mutableSummary.itemCountByTagId[tagId] ?? 0) + 1;
+        (mutableSummary.itemCountByTagId[tagId] ?? 0) + delta;
     }
   },
-  unmutateSummary: (mutableSummary, item) => {
-    mutableSummary.itemCount -= 1;
-    for (const tagId of item.tagIds) {
-      mutableSummary.itemCountByTagId[tagId] =
-        (mutableSummary.itemCountByTagId[tagId] ?? 1) - 1;
-    }
-  },
-};
+});

--- a/src/shared/@model/static-lists/=announcements.ts
+++ b/src/shared/@model/static-lists/=announcements.ts
@@ -3,9 +3,12 @@ import { z } from "zod/mini";
 import { itemCountSchema } from "../../@primitives/misc";
 import { semverRangeSchema } from "../../@primitives/semver";
 import { isoDateTimeSchema } from "../../@primitives/temporal";
-import type { StaticListDefinition } from "../static-list-helpers";
+import {
+  defineStaticListDefinition,
+  type StaticListDefinition,
+} from "../static-list-helpers";
 
-const announcementListItemSchema = z.readonly(
+const jsonlAnnouncementListItemSchema = z.readonly(
   z.tuple([
     isoDateTimeSchema, // createdAt
     z // extensionVersionRange or [extensionVersionRange, extensionVersionRangeForToast]
@@ -18,9 +21,11 @@ const announcementListItemSchema = z.readonly(
   ]),
 );
 /** @public */
-export type AnnouncementListItem = z.infer<typeof announcementListItemSchema>;
+export type AnnouncementListItem = z.infer<
+  typeof interpretedAnnouncementListItemSchema
+>;
 
-export const storedAnnouncementListItemSchema = z.readonly(
+export const interpretedAnnouncementListItemSchema = z.readonly(
   z.object({
     createdAt: isoDateTimeSchema,
     extensionVersionRange: semverRangeSchema,
@@ -37,14 +42,20 @@ const announcementListSummarySchema = z.readonly(
 );
 
 export const announcementListDefinition: StaticListDefinition<
-  typeof announcementListItemSchema,
-  typeof storedAnnouncementListItemSchema,
+  typeof jsonlAnnouncementListItemSchema,
+  typeof interpretedAnnouncementListItemSchema,
   typeof announcementListSummarySchema
-> = {
+> = defineStaticListDefinition({
   dxSidepanelTab: { label: "Объявления" },
-  receivedItemSchema: announcementListItemSchema,
-  storedItemSchema: storedAnnouncementListItemSchema,
-  mapReceivedToStored: ([
+  physicalStorageVersion: 1,
+  derivedDataVersion: "20260321",
+  jsonlItemSchema: jsonlAnnouncementListItemSchema,
+  interpretedItemSchema: interpretedAnnouncementListItemSchema,
+  logicalPrimaryKey: {
+    name: "createdAt",
+    extractFromJsonlItem: ([createdAt]) => createdAt,
+  },
+  interpretJsonlItem: ([
     createdAt,
     extensionVersionRange,
     header,
@@ -62,7 +73,7 @@ export const announcementListDefinition: StaticListDefinition<
     content,
   }),
 
-  mapStoredToReceived: ({
+  serializeInterpretedItemAsJsonl: ({
     createdAt,
     extensionVersionRange,
     extensionVersionRangeForToast,
@@ -77,18 +88,13 @@ export const announcementListDefinition: StaticListDefinition<
     content,
   ],
 
-  jsonlRowSortingBy: ["createdAt"],
-
-  indexes: ["createdAt"],
+  jsonlExportSortingBy: ["createdAt"],
 
   summarySchema: announcementListSummarySchema,
   createEmptySummary: () => ({
     itemCount: 0,
   }),
-  mutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount += 1;
+  adjustSummary: (mutableSummary, item, delta) => {
+    mutableSummary.itemCount += delta;
   },
-  unmutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount -= 1;
-  },
-};
+});

--- a/src/shared/@model/static-lists/=insertions.ts
+++ b/src/shared/@model/static-lists/=insertions.ts
@@ -2,7 +2,10 @@ import { z } from "zod/mini";
 
 import { itemCountSchema } from "../../@primitives/misc";
 import { insertionConfigSchema } from "../insertion-configs";
-import type { StaticListDefinition } from "../static-list-helpers";
+import {
+  defineStaticListDefinition,
+  type StaticListDefinition,
+} from "../static-list-helpers";
 
 const insertionListItemSchema = insertionConfigSchema;
 /** @public */
@@ -24,12 +27,18 @@ export const insertionListDefinition: StaticListDefinition<
   typeof insertionListItemSchema,
   typeof insertionListItemSchema,
   typeof insertionListSummarySchema
-> = {
+> = defineStaticListDefinition({
   dxSidepanelTab: { label: "Вставки" },
-  receivedItemSchema: insertionListItemSchema,
-  storedItemSchema: insertionListItemSchema,
-  mapReceivedToStored: (receivedItem) => receivedItem,
-  mapStoredToReceived: (storedItem) => {
+  physicalStorageVersion: 1,
+  derivedDataVersion: "20260321",
+  jsonlItemSchema: insertionListItemSchema,
+  interpretedItemSchema: insertionListItemSchema,
+  logicalPrimaryKey: {
+    name: "id",
+    extractFromJsonlItem: (jsonlItem) => jsonlItem.id,
+  },
+  interpretJsonlItem: (jsonlItem) => jsonlItem,
+  serializeInterpretedItemAsJsonl: (storedItem) => {
     const {
       disabled,
       appliesTo,
@@ -64,18 +73,13 @@ export const insertionListDefinition: StaticListDefinition<
         (match, p1: string) =>
           `variant":"${p1}",${" ".repeat(insertionVariantMaxLength - p1.length)}`,
       ),
-  jsonlRowSortingBy: ["variant", "disabled", "extensionVersionRange", "id"],
-
-  indexes: ["id"],
+  jsonlExportSortingBy: ["variant", "disabled", "extensionVersionRange", "id"],
 
   summarySchema: insertionListSummarySchema,
   createEmptySummary: () => ({
     itemCount: 0,
   }),
-  mutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount += 1;
+  adjustSummary: (mutableSummary, item, delta) => {
+    mutableSummary.itemCount += delta;
   },
-  unmutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount -= 1;
-  },
-};
+});

--- a/src/shared/@model/static-lists/=tags.ts
+++ b/src/shared/@model/static-lists/=tags.ts
@@ -9,11 +9,13 @@ import {
 } from "../../@primitives/misc";
 import { omitUndefined } from "../../omit-undefined";
 import {
+  defineStaticListDefinition,
   receivedTagIdSchema,
   type StaticListDefinition,
+  stringifyReceivedTagId,
 } from "../static-list-helpers";
 
-const receivedTagListItemSchema = z.readonly(
+const jsonlTagListItemSchema = z.readonly(
   z.tuple([
     z.union([
       hexColorSchema,
@@ -28,8 +30,9 @@ const receivedTagListItemSchema = z.readonly(
     z.exactOptional(z.string()), // customPathname
   ]),
 );
+type JsonlTagListItem = z.infer<typeof jsonlTagListItemSchema>;
 
-const storedTagListItemSchema = z.readonly(
+const interpretedTagListItemSchema = z.readonly(
   z.object({
     color: z.exactOptional(hexColorSchema),
     colorForHighlight: z.exactOptional(hexColorSchema),
@@ -45,7 +48,7 @@ const storedTagListItemSchema = z.readonly(
   }),
 );
 /** @public */
-export type TagListItem = z.infer<typeof storedTagListItemSchema>;
+export type TagListItem = z.infer<typeof interpretedTagListItemSchema>;
 
 const tagListSummarySchema = z.readonly(
   z.object({
@@ -62,14 +65,20 @@ function expandFlagBitmask(flagBitmask: number): Partial<TagListItem> {
 }
 
 export const tagListDefinition: StaticListDefinition<
-  typeof receivedTagListItemSchema,
-  typeof storedTagListItemSchema,
+  typeof jsonlTagListItemSchema,
+  typeof interpretedTagListItemSchema,
   typeof tagListSummarySchema
-> = {
+> = defineStaticListDefinition({
   dxSidepanelTab: { label: "Теги" },
-  receivedItemSchema: receivedTagListItemSchema,
-  storedItemSchema: storedTagListItemSchema,
-  mapReceivedToStored: ([
+  physicalStorageVersion: 1,
+  derivedDataVersion: "20260321",
+  jsonlItemSchema: jsonlTagListItemSchema,
+  interpretedItemSchema: interpretedTagListItemSchema,
+  logicalPrimaryKey: {
+    name: "id",
+    extractFromJsonlItem: (jsonlItem) => stringifyReceivedTagId(jsonlItem[2]),
+  },
+  interpretJsonlItem: ([
     color,
     type,
     rawId,
@@ -81,47 +90,52 @@ export const tagListDefinition: StaticListDefinition<
       color: Array.isArray(color) ? color[0] : (color ?? undefined),
       colorForHighlight: Array.isArray(color) ? color[1] : undefined,
       type,
-      id: tagIdSchema.parse(String(rawId)),
+      id: stringifyReceivedTagId(rawId),
       name,
       ...expandFlagBitmask(flagBitmask ?? 0),
       customPathname,
     }),
 
-  mapStoredToReceived: (storedItem) => {
+  serializeInterpretedItemAsJsonl: (storedItem): JsonlTagListItem => {
     const flagBitmask =
       (storedItem.botnadzorPage ? 1 : 0) |
       (storedItem.botnadzorCard ? 2 : 0) |
       (storedItem.visibilityLock ? 4 : 0);
-
-    const baseResult = [
-      // eslint-disable-next-line unicorn/no-null -- need to map to JSON
-      storedItem.color ?? null,
-      storedItem.type,
-      storedItem.id,
-      storedItem.name,
-    ] as const;
+    const color: JsonlTagListItem[0] =
+      storedItem.color && storedItem.colorForHighlight
+        ? [storedItem.color, storedItem.colorForHighlight]
+        : // eslint-disable-next-line unicorn/no-null -- need to map to JSON
+          (storedItem.color ?? null);
 
     if (storedItem.customPathname) {
-      return [...baseResult, flagBitmask, storedItem.customPathname];
+      return [
+        color,
+        storedItem.type,
+        storedItem.id,
+        storedItem.name,
+        flagBitmask,
+        storedItem.customPathname,
+      ];
     }
 
     if (flagBitmask) {
-      return [...baseResult, flagBitmask];
+      return [
+        color,
+        storedItem.type,
+        storedItem.id,
+        storedItem.name,
+        flagBitmask,
+      ];
     }
 
-    return baseResult;
+    return [color, storedItem.type, storedItem.id, storedItem.name];
   },
-
-  indexes: ["id"],
 
   summarySchema: tagListSummarySchema,
   createEmptySummary: () => ({
     itemCount: 0,
   }),
-  mutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount += 1;
+  adjustSummary: (mutableSummary, item, delta) => {
+    mutableSummary.itemCount += delta;
   },
-  unmutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount -= 1;
-  },
-};
+});

--- a/src/shared/@model/static-lists/=walls.ts
+++ b/src/shared/@model/static-lists/=walls.ts
@@ -2,21 +2,21 @@ import { z } from "zod/mini";
 
 import { itemCountSchema } from "../../@primitives/misc";
 import { vkIdSchema } from "../../@primitives/vk";
-import type { StaticListDefinition } from "../static-list-helpers";
+import {
+  defineStaticListDefinition,
+  type StaticListDefinition,
+} from "../static-list-helpers";
 
-const receivedWallListItemSchema = z.union([
-  z.readonly(z.tuple([vkIdSchema])),
-  vkIdSchema,
-]);
+const jsonlWallListItemSchema = z.readonly(z.tuple([vkIdSchema]));
 
-const storedWallListItemSchema = z.readonly(
+const interpretedWallListItemSchema = z.readonly(
   z.object({
     vkId: vkIdSchema,
     skip: z.boolean(), // true if the wall should be skipped when a user has opted in to collecting comments
   }),
 );
 /** @public */
-export type WallListItem = z.infer<typeof storedWallListItemSchema>;
+export type WallListItem = z.infer<typeof interpretedWallListItemSchema>;
 
 const wallListSummarySchema = z.readonly(
   z.object({
@@ -25,29 +25,31 @@ const wallListSummarySchema = z.readonly(
 );
 
 export const wallListDefinition: StaticListDefinition<
-  typeof receivedWallListItemSchema,
-  typeof storedWallListItemSchema,
+  typeof jsonlWallListItemSchema,
+  typeof interpretedWallListItemSchema,
   typeof wallListSummarySchema
-> = {
+> = defineStaticListDefinition({
   dxSidepanelTab: { label: "Стены" },
-  receivedItemSchema: receivedWallListItemSchema,
-  storedItemSchema: storedWallListItemSchema,
-  mapReceivedToStored: (receivedItem) => ({
-    vkId: typeof receivedItem === "number" ? receivedItem : receivedItem[0],
+  physicalStorageVersion: 1,
+  derivedDataVersion: "20260321",
+  jsonlItemSchema: jsonlWallListItemSchema,
+  interpretedItemSchema: interpretedWallListItemSchema,
+  logicalPrimaryKey: {
+    name: "vkId",
+    extractFromJsonlItem: ([vkId]) => vkId,
+  },
+  interpretJsonlItem: ([vkId]) => ({
+    vkId,
     skip: true,
   }),
 
-  mapStoredToReceived: ({ vkId }) => vkId,
-  indexes: ["vkId"],
+  serializeInterpretedItemAsJsonl: ({ vkId }) => [vkId],
 
   summarySchema: wallListSummarySchema,
   createEmptySummary: () => ({
     itemCount: 0,
   }),
-  mutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount += 1;
+  adjustSummary: (mutableSummary, item, delta) => {
+    mutableSummary.itemCount += delta;
   },
-  unmutateSummary: (mutableSummary) => {
-    mutableSummary.itemCount -= 1;
-  },
-};
+});

--- a/src/shared/@ui-helpers/data-hooks.ts
+++ b/src/shared/@ui-helpers/data-hooks.ts
@@ -2,6 +2,7 @@ import * as React from "react";
 import type { JsonValue } from "type-fest";
 
 import type { AnnouncementVersionFilter } from "../../entrypoints/background/@services/extension-version-service";
+import type { StaticListMetadata } from "../@model/static-list-metadata";
 import type {
   StaticListId,
   StaticListItem,
@@ -69,19 +70,19 @@ export const useGlobalNotificationsState = createPollableValueHook(
   { hookNameForDebugging: "useGlobalNotificationsState" },
 );
 
-type UseRemoteNextStaticListSummary = <ListId extends StaticListId>(
+type UseRemoteStagingStaticListSummary = <ListId extends StaticListId>(
   listId: ListId,
-) => StaticListSummary<ListId>;
+) => StaticListSummary<ListId> | undefined;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Mapping generic list return type to specific list summary shape
-export const useRemoteNextStaticListSummary = createPollableValueHook(
+export const useRemoteStagingStaticListSummary = createPollableValueHook(
   (lastPollVersion, listId: StaticListId) =>
-    staticListsService.pollRemoteNextListSummary(lastPollVersion, listId),
+    staticListsService.pollRemoteStagingSummary(lastPollVersion, listId),
   {
-    hookNameForDebugging: "useRemoteNextStaticListSummary",
+    hookNameForDebugging: "useRemoteStagingStaticListSummary",
     throttleInterval: 100,
   },
-) as UseRemoteNextStaticListSummary;
+) as UseRemoteStagingStaticListSummary;
 
 type UseStaticListItems = <ListId extends StaticListId>(
   listId: ListId,
@@ -94,11 +95,16 @@ export const useStaticListItems = createPollableValueHook(
   { hookNameForDebugging: "useStaticListItems" },
 ) as UseStaticListItems;
 
+type UseStaticListMetadata = <ListId extends StaticListId>(
+  listId: ListId,
+) => StaticListMetadata<ListId>;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Mapping generic list return type to specific list metadata shape
 export const useStaticListMetadata = createPollableValueHook(
   (lastPollVersion, listId: StaticListId) =>
     staticListsService.pollListMetadata(lastPollVersion, listId),
   { hookNameForDebugging: "useStaticListMetadata" },
-);
+) as UseStaticListMetadata;
 
 type UseStaticListSummary = <ListId extends StaticListId>(
   listId: ListId,

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
       }
     },
 
-    "entrypoints:found": (_wxt, entrypointInfos) => {
+    "entrypoints:found": (wxt, entrypointInfos) => {
       if (process.env["WXT_DX_FEATURES_ENABLED"] !== "true") {
         const index = entrypointInfos.findIndex(
           (ep) => ep.name === "sidepanel",


### PR DESCRIPTION
Суть изменения: раньше списки JSONL интерпретировали до сохранения в базу. Это могло привести к тому, что данные для новой версии записалось в старой версии и частично отбросились. Такая потеря данных могла вызвать ошибку после обновления расширения. Пример: конфиги вставок с новыми типами или фичами.

В новой версии сервиса строчки JSON складываются в базу «как есть» — мы лишь извлекаем из них индексы. Теперь данные интерпретируются при чтении, что делает процесс более гибким и надёжным. Если структура индексов меняется, мы полностью удаляем базу для конкретного списка.

Вместо того, чтобы подкручивать существующую логику, я сконвертирвал код сервиса в спеку, улучшил спеку и перевёл её обратно в код. Кроме фикса описанного выше бага получили более надёжную логику для всего процесса. Теперь все списки хранятся в отдельных базах, что позволяет менеджить их независимо друг от друга:

```
static-lists:accounts:remote_a
static-lists:accounts:remote_b
static-lists:announcements:local ← создаётся только в режиме отладки
static-lists:announcements:remote_a
static-lists:announcements:remote_b
...
```

Каждая база имеет одну таблицу `rows`.