### PR TITLE
Improve announcement ordering and toast display / filtering

### DIFF
--- a/src/entrypoints/background/@services/extension-version-service.ts
+++ b/src/entrypoints/background/@services/extension-version-service.ts
@@ -14,21 +14,44 @@ import type { RootConfigService } from "./root-config-service";
 import type { StaticListsService } from "./static-lists-service";
 
 /**
- * Determines which semver range field to use for filtering announcements.
+ * Determines how announcements are filtered by extension version.
  *
- * - `"default"`: Always uses `extensionVersionRange`. This is the primary
- *   version range that determines general visibility of the announcement.
+ * - `"default"`: Uses only `extensionVersionRange`, which controls whether the
+ *   announcement is visible at all.
  *
- * - `"toast"`: Uses `extensionVersionRangeForToast` if present, otherwise
- *   falls back to `extensionVersionRange`. This allows announcements to have
- *   a narrower version range for toasts while being visible in the default
- *   view for a wider range.
+ * - `"toast"`: First applies `extensionVersionRange`, then additionally applies
+ *   `extensionVersionRangeForToast` when present. This allows toast visibility
+ *   to be narrower than the general announcement visibility, but never wider.
  *
- * Note that announcements are filtered only if the current extension version
- * is a release or a prerelease (e.g. 2.0.0 or 2.0.0-beta.1). Snapshots (i.e.
- * builds from commits or local development builds) do not filter announcements.
+ * Announcements are filtered only for release and prerelease builds
+ * (e.g. 2.0.0 or 2.0.0-beta.1). Snapshot builds do not filter announcements.
  */
 export type AnnouncementVersionFilter = "default" | "toast";
+
+function checkVersionRange(versionToUse: string, semverRange: string): boolean {
+  return semverSatisfies(versionToUse, semverRange, {
+    includePrerelease: true,
+  });
+}
+
+function applyFilter(
+  announcement: StaticListItem<"announcements">,
+  filter: AnnouncementVersionFilter,
+  versionToUse: string,
+): boolean {
+  if (!checkVersionRange(versionToUse, announcement.extensionVersionRange)) {
+    return false;
+  }
+
+  if (filter !== "toast" || !announcement.extensionVersionRangeForToast) {
+    return true;
+  }
+
+  return checkVersionRange(
+    versionToUse,
+    announcement.extensionVersionRangeForToast,
+  );
+}
 
 export class ExtensionVersionService {
   private readonly rootConfigService: RootConfigService;
@@ -113,17 +136,9 @@ export class ExtensionVersionService {
       return result;
     }
 
-    const filteredItems = result.value.filter((announcement) => {
-      const semverRangeToUse =
-        filter === "default"
-          ? announcement.extensionVersionRange
-          : (announcement.extensionVersionRangeForToast ??
-            announcement.extensionVersionRange);
-
-      return semverSatisfies(versionToUse, semverRangeToUse, {
-        includePrerelease: true,
-      });
-    });
+    const filteredItems = result.value.filter((announcement) =>
+      applyFilter(announcement, filter, versionToUse),
+    );
 
     return { value: filteredItems, version: result.version };
   }

--- a/src/entrypoints/content/in-page-app/toasts.tsx
+++ b/src/entrypoints/content/in-page-app/toasts.tsx
@@ -113,11 +113,14 @@ export function Toasts() {
     );
   }
 
-  const announcementToShow = announcements.find(
-    ({ createdAt }) =>
-      !announcementReadAtByCreatedAt[createdAt] &&
-      createdAt > welcomeMessageReadAt,
-  );
+  const announcementToShow = announcements
+    // Show older announcements first
+    .toSorted((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .find(
+      ({ createdAt }) =>
+        !announcementReadAtByCreatedAt[createdAt] &&
+        createdAt > welcomeMessageReadAt,
+    );
 
   if (announcementToShow) {
     return (

--- a/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
+++ b/src/entrypoints/content/in-page-app/toasts/toast-with-data-warmup.tsx
@@ -5,17 +5,15 @@ import { useStaticListMetadata } from "@/shared/@ui-helpers/data-hooks";
 
 import { Toast } from "./toast";
 
-// Minimum time before we even consider showing the toast.
-const showToastAfterMs = 2000;
+// Wait for one observed interval before deciding whether the toast is needed.
+const startForecastingAfterMs = 1000;
 
 // Show the toast if the linearly-extrapolated remaining time exceeds this.
-// Example: at 2 s in with 50 % done → ~2 s estimated remaining → show.
-//          at 2 s in with 98 % done → ~40 ms estimated remaining  → skip.
+// Example: if we first saw 40 % and after 1 s we see 50 %, we estimate the
+// remaining time from that observed speed instead of assuming we started at 0 %.
 const showIfEstimatedRemainingMoreThanMs = 2000;
 
-// Also show if progress hasn't moved for this long after the initial delay.
-// Handles the case where loading sprints to a high percentage and then stalls.
-const showIfProgressStuckForMs = 2000;
+const forecastCheckIntervalMs = 1000;
 
 export function ToastWithDataWarmup({ onDone }: { onDone: () => void }) {
   const accountsMetadata = useStaticListMetadata("accounts");
@@ -46,52 +44,60 @@ export function ToastWithDataWarmup({ onDone }: { onDone: () => void }) {
     : 95;
 
   // Refs let the interval callback read the latest values without being
-  // re-registered on every render. Initialized and synced via effect -
-  // avoids calling Date.now() during render.
-  const mountTimeRef = React.useRef<number | undefined>(undefined);
+  // re-registered on every render.
+  const initialProgressMeasuredAtRef = React.useRef<number | undefined>(
+    undefined,
+  );
+  const initialProgressRef = React.useRef<number | undefined>(undefined);
   const progressRef = React.useRef(progressInPercentage);
-  const lastProgressChangeAtRef = React.useRef<number | undefined>(undefined);
+
   React.useEffect(() => {
-    const now = Date.now();
-    if (mountTimeRef.current === undefined) {
-      mountTimeRef.current = now;
-      lastProgressChangeAtRef.current = now;
-    } else if (progressInPercentage !== progressRef.current) {
-      lastProgressChangeAtRef.current = now;
+    if (initialProgressMeasuredAtRef.current === undefined) {
+      initialProgressMeasuredAtRef.current = Date.now();
+      initialProgressRef.current = progressInPercentage;
     }
+
     progressRef.current = progressInPercentage;
-  });
+  }, [progressInPercentage]);
 
   const [shouldShow, setShouldShow] = React.useState(false);
 
   React.useEffect(() => {
     function check() {
-      const mountTime = mountTimeRef.current;
-      const lastProgressChangeAt = lastProgressChangeAtRef.current;
-      if (mountTime === undefined || lastProgressChangeAt === undefined) {
+      const initialProgressMeasuredAt = initialProgressMeasuredAtRef.current;
+      const initialProgress = initialProgressRef.current;
+
+      if (
+        initialProgressMeasuredAt === undefined ||
+        initialProgress === undefined
+      ) {
         return;
       }
 
       const now = Date.now();
-      const elapsed = now - mountTime;
-      if (elapsed < showToastAfterMs) {
+      const elapsed = now - initialProgressMeasuredAt;
+
+      if (elapsed < startForecastingAfterMs) {
         return;
       }
 
-      const progress = progressRef.current;
-      const estimatedRemaining =
-        progress > 0 ? (elapsed * (100 - progress)) / progress : Infinity;
-      const timeSinceProgressChange = now - lastProgressChangeAt;
+      const currentProgress = progressRef.current;
+      const observedProgressDelta = currentProgress - initialProgress;
 
-      if (
-        estimatedRemaining > showIfEstimatedRemainingMoreThanMs ||
-        timeSinceProgressChange > showIfProgressStuckForMs
-      ) {
+      if (observedProgressDelta <= 0) {
+        setShouldShow(true);
+        return;
+      }
+
+      const estimatedRemaining =
+        (elapsed * (100 - currentProgress)) / observedProgressDelta;
+
+      if (estimatedRemaining > showIfEstimatedRemainingMoreThanMs) {
         setShouldShow(true);
       }
     }
 
-    const interval = setInterval(check, 500);
+    const interval = setInterval(check, forecastCheckIntervalMs);
     return () => {
       clearInterval(interval);
     };

--- a/src/entrypoints/popup/app/tabs/=announcements.tsx
+++ b/src/entrypoints/popup/app/tabs/=announcements.tsx
@@ -16,7 +16,10 @@ export function AnnouncementsTabBody() {
   const announcements = useFilteredAnnouncements("default");
   const frontendBaseUrl = useFrontendBaseUrl();
 
-  const announcementsToShow = announcements.toReversed();
+  // Show newer announcements first
+  const announcementsToShow = announcements.toSorted((a, b) =>
+    b.createdAt.localeCompare(a.createdAt),
+  );
 
   return (
     <div className="px-3 pt-2 pb-4">


### PR DESCRIPTION
- В попапе объявления теперь сортируются по `createdAt` в обратном порядке, поэтому сверху показываются более свежие объявления.
- Для announcement toast исправлен порядок фильтрации по версиям расширения: сначала всегда проверяется `extensionVersionRange`, и только потом, при наличии, дополнительно проверяется `extensionVersionRangeForToast`. Это исключает ситуацию, когда toast показывается шире, чем само объявление.
- Исправлена логика показа `data warm-up` toast: теперь прогноз строится не от условного `0%`, а от первого реально наблюдаемого прогресса после маунта компонента.
- Для `data warm-up` toast добавлена повторная переоценка прогноза раз в секунду, чтобы toast мог появиться и в случае, когда загрузка сначала идёт быстро, а потом заметно замедляется или зависает.