### PR TITLE
Add insertionDataInDom DX flag

### DIFF
--- a/src/entrypoints/content/insertion-management.ts
+++ b/src/entrypoints/content/insertion-management.ts
@@ -83,12 +83,15 @@ export async function startManagingInsertions({
 
   updateConfigs(initialDxConfig.insertionsRemoved ? [] : initialItems);
 
+  let latestDxConfig = initialDxConfig;
+
   mountNewInsertions({
     configs: currentConfigs,
     contentId,
     contentLogger,
     derivedPageInfo,
     instanceMap,
+    dxConfig: initialDxConfig,
   });
 
   let throttleTimeout: number | undefined;
@@ -103,6 +106,7 @@ export async function startManagingInsertions({
         contentLogger,
         derivedPageInfo,
         instanceMap,
+        dxConfig: latestDxConfig,
       });
       throttleTimeout = undefined;
     }, 100);
@@ -118,8 +122,12 @@ export async function startManagingInsertions({
     instanceMap,
     contentLogger,
     contentId,
+    initialDxConfig,
     getConfigs: () => currentConfigs,
     onConfigsChanged: updateConfigs,
+    onDxConfigChanged: (config) => {
+      latestDxConfig = config;
+    },
   });
 
   window.addEventListener("beforeunload", () => {

--- a/src/entrypoints/content/insertion-management/global-rerender.ts
+++ b/src/entrypoints/content/insertion-management/global-rerender.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "@logtape/logtape";
 
-import type { DxConfig } from "@/shared/@model/dx-config";
+import { defaultDxConfig, type DxConfig } from "@/shared/@model/dx-config";
 import type { InsertionConfig } from "@/shared/@model/insertion-configs";
 import type { StaticListItem } from "@/shared/@model/static-lists";
 import type { PollVersion } from "@/shared/@pollable/core";
@@ -18,29 +18,36 @@ import {
   type InsertionInstanceMap,
   mountNewInsertions,
   refreshExistingInsertions,
+  syncElementDataAttributes,
 } from "./instance-lifecycle";
 
 let lastInsertionConfigs: InsertionConfig[] | undefined;
 
 let lastDxInsertionsRemoved: boolean | undefined;
 let lastDxInsertionForceRerenderedAt: string | undefined;
+let lastDxConfig: DxConfig = defaultDxConfig;
 
 export function startGlobalRerenderPolling({
   contentId,
   contentLogger,
   derivedPageInfo,
   getConfigs,
+  initialDxConfig,
   instanceMap,
   onConfigsChanged,
+  onDxConfigChanged,
 }: {
   derivedPageInfo: DerivedPageInfo;
   contentId: ContentId;
   contentLogger: Logger;
   getConfigs: () => InsertionConfig[];
+  initialDxConfig: DxConfig;
   instanceMap: InsertionInstanceMap;
   onConfigsChanged: (configs: InsertionConfig[]) => void;
+  onDxConfigChanged?: (dxConfig: DxConfig) => void;
 }): () => void {
   let disposed = false;
+  lastDxConfig = initialDxConfig;
 
   const logger = contentLogger.getChild([
     "insertion-management",
@@ -63,12 +70,14 @@ export function startGlobalRerenderPolling({
       contentId,
       contentLogger,
       derivedPageInfo,
+      dxConfig: lastDxConfig,
     });
     refreshExistingInsertions({
       contentId,
       contentLogger,
       derivedPageInfo,
       instanceMap,
+      dxConfig: lastDxConfig,
     });
   }
 
@@ -141,6 +150,27 @@ export function startGlobalRerenderPolling({
           }
           lastDxInsertionForceRerenderedAt = currentInsertionForceRenderedAtAt;
         }
+
+        if (
+          dxConfig.insertionDataInDom !== lastDxConfig.insertionDataInDom ||
+          dxConfig.insertionLabeling !== lastDxConfig.insertionLabeling ||
+          dxConfig.insertionFraming !== lastDxConfig.insertionFraming
+        ) {
+          for (const instance of instanceMap.values()) {
+            syncElementDataAttributes(instance.rootElement, dxConfig, {
+              innerData: instance.innerData,
+              ...("markupData" in instance && {
+                markupData: instance.markupData,
+              }),
+              ...("serviceData" in instance && {
+                serviceData: instance.serviceData,
+              }),
+            });
+          }
+        }
+
+        lastDxConfig = dxConfig;
+        onDxConfigChanged?.(dxConfig);
       },
     } satisfies ThingToPoll<DxConfig>,
     {

--- a/src/entrypoints/content/insertion-management/instance-lifecycle.ts
+++ b/src/entrypoints/content/insertion-management/instance-lifecycle.ts
@@ -4,6 +4,7 @@ import { produce } from "immer";
 import { nanoid } from "nanoid";
 import type { JsonObject } from "type-fest";
 
+import type { DxConfig } from "@/shared/@model/dx-config";
 import type { InsertionConfig } from "@/shared/@model/insertion-configs";
 import type { ContentId } from "@/shared/@primitives/misc";
 import {
@@ -35,6 +36,60 @@ const insertionMarkupDataKey = "bnInsertionMarkupData";
 const insertionServiceDataKey = "bnInsertionServiceData";
 
 export type InsertionInstanceMap = Map<string, InsertionInstance>;
+
+/**
+ * Syncs the three JSON data attributes on an insertion's root element according
+ * to the current dxConfig. Pass only the keys whose data you want to manage;
+ * omitted keys are left untouched.
+ *
+ * - insertionDataInDom on  → write JSON for each provided key
+ * - insertionDataInDom off → delete inner/service; write sentinel "present" for
+ *   markup if labeling/framing is on, otherwise delete it
+ */
+export function syncElementDataAttributes(
+  rootElement: HTMLElement,
+  dxConfig: DxConfig,
+  data: {
+    innerData?: JsonObject;
+    markupData?: JsonObject;
+    serviceData?: JsonObject;
+  },
+): void {
+  if (dxConfig.insertionDataInDom) {
+    if (data.innerData !== undefined) {
+      rootElement.dataset[insertionInnerDataKey] = JSON.stringify(
+        data.innerData,
+      );
+    }
+    if (data.markupData !== undefined) {
+      rootElement.dataset[insertionMarkupDataKey] = JSON.stringify(
+        data.markupData,
+      );
+    }
+    if (data.serviceData !== undefined) {
+      rootElement.dataset[insertionServiceDataKey] = JSON.stringify(
+        data.serviceData,
+      );
+    }
+    return;
+  }
+  if (data.innerData !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is a runtime const
+    delete rootElement.dataset[insertionInnerDataKey];
+  }
+  if (data.serviceData !== undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is a runtime const
+    delete rootElement.dataset[insertionServiceDataKey];
+  }
+  if (data.markupData !== undefined) {
+    if (dxConfig.insertionLabeling || dxConfig.insertionFraming) {
+      rootElement.dataset[insertionMarkupDataKey] = "present";
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is a runtime const
+      delete rootElement.dataset[insertionMarkupDataKey];
+    }
+  }
+}
 
 const serviceLookup: AvailableServiceLookup = {
   affiliationService,
@@ -86,6 +141,7 @@ export function mountInstance(
   contentLogger: Logger,
   instanceMap: InsertionInstanceMap,
   derivedPageInfo: DerivedPageInfo,
+  dxConfig: DxConfig,
 ): MountedInsertionInstance {
   const definition = insertionVariantLookup[instance.config.variant];
 
@@ -129,10 +185,10 @@ export function mountInstance(
         return;
       }
 
-      instanceAfterRevalidate.rootElement.dataset[insertionMarkupDataKey] =
-        JSON.stringify(newMarkupData);
-      instanceAfterRevalidate.rootElement.dataset[insertionServiceDataKey] =
-        JSON.stringify(newServiceData);
+      syncElementDataAttributes(instanceAfterRevalidate.rootElement, dxConfig, {
+        markupData: newMarkupData,
+        serviceData: newServiceData,
+      });
 
       instanceMap.set(instance.instanceId, {
         ...instanceAfterRevalidate,
@@ -176,7 +232,7 @@ export function mountInstance(
 
         // Trigger re-render automatically
         // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive with mountInstance; call is deferred via callback
-        requestInstanceRerender(instance.instanceId, instanceMap);
+        requestInstanceRerender(instance.instanceId, instanceMap, dxConfig);
       }
     },
   });
@@ -193,6 +249,7 @@ export function mountInstance(
 function requestInstanceRerender(
   instanceId: string,
   instanceMap: InsertionInstanceMap,
+  dxConfig: DxConfig,
 ): void {
   const instance = instanceMap.get(instanceId);
   if (!instance || !("render" in instance)) {
@@ -218,13 +275,10 @@ function requestInstanceRerender(
       serviceData: current.serviceData,
     });
 
-    current.rootElement.dataset[insertionInnerDataKey] = JSON.stringify(
-      current.innerData,
-    );
-
-    current.rootElement.dataset[insertionServiceDataKey] = JSON.stringify(
-      current.serviceData,
-    );
+    syncElementDataAttributes(current.rootElement, dxConfig, {
+      innerData: current.innerData,
+      serviceData: current.serviceData,
+    });
   });
 }
 
@@ -265,11 +319,13 @@ export function mountNewInsertions({
   instanceMap,
   contentId,
   derivedPageInfo,
+  dxConfig,
 }: {
   configs: InsertionConfig[];
   contentId: ContentId;
   contentLogger: Logger;
   derivedPageInfo: DerivedPageInfo;
+  dxConfig: DxConfig;
   instanceMap: InsertionInstanceMap;
 }): void {
   const logger = contentLogger.getChild(["insertion-management", "mount"]);
@@ -304,8 +360,9 @@ export function mountNewInsertions({
       const initialInnerData = definition.defaultInnerData;
 
       rootElement.dataset[insertionInstanceIdKey] = instanceId;
-      rootElement.dataset[insertionInnerDataKey] =
-        JSON.stringify(initialInnerData);
+      syncElementDataAttributes(rootElement, dxConfig, {
+        innerData: initialInnerData,
+      });
 
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is a runtime const
       delete rootElement.dataset[insertionMarkupDataKey];
@@ -348,10 +405,10 @@ export function mountNewInsertions({
             return;
           }
 
-          instance.rootElement.dataset[insertionMarkupDataKey] =
-            JSON.stringify(markupData);
-          instance.rootElement.dataset[insertionServiceDataKey] =
-            JSON.stringify(serviceData);
+          syncElementDataAttributes(instance.rootElement, dxConfig, {
+            markupData,
+            serviceData,
+          });
 
           const mountedInstance = mountInstance(
             { ...instance, markupData, serviceData },
@@ -359,6 +416,7 @@ export function mountNewInsertions({
             contentLogger,
             instanceMap,
             derivedPageInfo,
+            dxConfig,
           );
 
           instanceMap.set(instanceId, mountedInstance);
@@ -383,10 +441,12 @@ export function refreshExistingInsertions({
   contentId,
   contentLogger,
   derivedPageInfo,
+  dxConfig,
 }: {
   contentId: ContentId;
   contentLogger: Logger;
   derivedPageInfo: DerivedPageInfo;
+  dxConfig: DxConfig;
   instanceMap: InsertionInstanceMap;
 }): void {
   const logger = contentLogger.getChild(["insertion-management", "refresh"]);
@@ -453,12 +513,11 @@ export function refreshExistingInsertions({
           instanceId,
         });
 
-        instanceAfterData.rootElement.dataset[insertionInnerDataKey] =
-          JSON.stringify(instanceAfterData.innerData);
-        instanceAfterData.rootElement.dataset[insertionMarkupDataKey] =
-          JSON.stringify(newMarkupData);
-        instanceAfterData.rootElement.dataset[insertionServiceDataKey] =
-          JSON.stringify(newServiceData);
+        syncElementDataAttributes(instanceAfterData.rootElement, dxConfig, {
+          innerData: instanceAfterData.innerData,
+          markupData: newMarkupData,
+          serviceData: newServiceData,
+        });
 
         if ("unmount" in instanceAfterData) {
           instanceAfterData.unmount();
@@ -474,6 +533,7 @@ export function refreshExistingInsertions({
           contentLogger,
           instanceMap,
           derivedPageInfo,
+          dxConfig,
         );
 
         instanceMap.set(instanceId, mountedInstance);

--- a/src/entrypoints/sidepanel/app/static-list-tab-body/additional-insertion-controls.tsx
+++ b/src/entrypoints/sidepanel/app/static-list-tab-body/additional-insertion-controls.tsx
@@ -37,6 +37,18 @@ export function AdditionalInsertionControls() {
     );
   }
 
+  function handleDataInDomChange(checked: boolean) {
+    void dxConfigService.set(
+      produce(dxConfig, (draft) => {
+        if (checked) {
+          draft.insertionDataInDom = true;
+        } else {
+          delete draft.insertionDataInDom;
+        }
+      }),
+    );
+  }
+
   function handleHiddenToggle() {
     const newConfig = produce(dxConfig, (draft) => {
       if (draft.insertionsRemoved) {
@@ -124,7 +136,7 @@ export function AdditionalInsertionControls() {
             onCheckedChange={handleFramingChange}
             disabled={insertionsRemoved}
           />
-          Рамки у вставок
+          Рамки вставок
         </Label>
         <Label className={cn(insertionsRemoved && "text-foreground/50")}>
           <Checkbox
@@ -134,7 +146,17 @@ export function AdditionalInsertionControls() {
             onCheckedChange={handleLabelingChange}
             disabled={insertionsRemoved}
           />
-          Метки у вставок
+          Метки вставок
+        </Label>
+        <Label className={cn(insertionsRemoved && "text-foreground/50")}>
+          <Checkbox
+            checked={
+              insertionsRemoved ? false : (dxConfig.insertionDataInDom ?? false)
+            }
+            onCheckedChange={handleDataInDomChange}
+            disabled={insertionsRemoved}
+          />
+          <code className="text-xs whitespace-nowrap">bn-insertion-*-data</code>
         </Label>
       </div>
     </div>

--- a/src/shared/@model/dx-config.ts
+++ b/src/shared/@model/dx-config.ts
@@ -9,6 +9,7 @@ export const staticListIdSchema = z.enum(staticListIds);
 export const dxConfigSchema = z.readonly(
   z.object({
     insertionForceRerenderedAt: z.exactOptional(isoDateTimeSchema),
+    insertionDataInDom: optionalTrueSchema,
     insertionFraming: optionalTrueSchema,
     insertionLabeling: optionalTrueSchema,
     insertionsRemoved: optionalTrueSchema,


### PR DESCRIPTION
Добавлен новый флаг dxConfig.insertionDataInDom, который управляет тем, записываются ли JSON-атрибуты вставок (inner-data, markup-data, service-data) в DOM. По умолчанию выключен — DOM остаётся чистым без больших JSON-блобов.

При переключении флага данные добавляются/удаляются в реальном времени. Это полезно для отладки. 
Особый случай: когда insertionDataInDom выключен, но включены insertionLabeling или insertionFraming, атрибут markup-data сохраняется со значением "present" (без JSON), чтобы CSS-селекторы могли различать состояния «загружается» и «загружено».

В боковой панели добавлен чекбокс рядом с «Рамки вставок» и «Метки вставок».

<img width="408" height="98" alt="Screenshot 2026-03-25 at 03 27 21" src="https://github.com/user-attachments/assets/7f45c097-6347-4b36-b5c6-0ba4edebb9ce" />
