### PR TITLE
Remove ORPC problem type `bn:ext:not-yet-known`

### DIFF
--- a/src/entrypoints/background/@service-helpers/dynamic-api-endpoints/=get-reg-date.ts
+++ b/src/entrypoints/background/@service-helpers/dynamic-api-endpoints/=get-reg-date.ts
@@ -13,7 +13,7 @@ import {
   problemSchemaForInvalidAccessCode,
   problemSchemaForInvalidPayload,
   problemSchemaForMissingPermission,
-  problemSchemaForNotYetKnown,
+  problemSchemaForNotFound,
   problemSchemaForRateLimited,
   problemSchemaForUnforeseenError,
 } from "./problems";
@@ -44,7 +44,7 @@ export const contractForGetRegDate = base
         problemSchemaForInvalidAccessCode,
         problemSchemaForInvalidPayload,
         problemSchemaForMissingPermission,
-        problemSchemaForNotYetKnown,
+        problemSchemaForNotFound,
         problemSchemaForRateLimited,
         problemSchemaForUnforeseenError,
       ]),

--- a/src/entrypoints/background/@service-helpers/dynamic-api-endpoints/problems.ts
+++ b/src/entrypoints/background/@service-helpers/dynamic-api-endpoints/problems.ts
@@ -32,12 +32,6 @@ export const problemSchemaForNotFound = z.object({
   description: z.string(),
 });
 
-export const problemSchemaForNotYetKnown = z.object({
-  problem: z.literal(true),
-  type: z.literal("bn:ext:not-yet-known"),
-  description: z.string(),
-});
-
 export const problemSchemaForRateLimited = z.object({
   problem: z.literal(true),
   type: z.literal("bn:ext:rate-limited"),


### PR DESCRIPTION
Объединены два очень похожих типа проблем в один: `bn:ext:not-yet-known` → `bn:ext:not-found`.

Исправляется такая ошибка:
<img width="332" height="111" alt="Screenshot 2026-03-26 at 00 12 06" src="https://github.com/user-attachments/assets/8c948929-a1c3-481b-8a26-607d097b685b" />
