### PR TITLE
Patch lodash for Firefox content script CSP

### DIFF
--- a/patches/lodash@4.17.23.patch
+++ b/patches/lodash@4.17.23.patch
@@ -1,0 +1,53 @@
+diff --git a/_root.js b/_root.js
+index d2852bed4d2e469b3b87ed31df2350047e005ff4..5d406e2e8c50c06d8e4dacb87733589322675aa0 100644
+--- a/_root.js
++++ b/_root.js
+@@ -3,7 +3,10 @@ var freeGlobal = require('./_freeGlobal');
+ /** Detect free variable `self`. */
+ var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+ 
+-/** Used as a reference to the global object. */
+-var root = freeGlobal || freeSelf || Function('return this')();
++/** Used as a reference to the global object without dynamic eval. */
++var freeGlobalThis = typeof globalThis == 'object' && globalThis &&
++  globalThis.Object === Object && globalThis;
++
++var root = freeGlobal || freeSelf || freeGlobalThis;
+ 
+ module.exports = root;
+diff --git a/core.js b/core.js
+index caf078f6987f2b47ef6485938ea51cd244f03ef2..c552cc9b5529e091ec107b4600c93af08c089b16 100644
+--- a/core.js
++++ b/core.js
+@@ -67,8 +67,11 @@
+   /** Detect free variable `self`. */
+   var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+ 
+-  /** Used as a reference to the global object. */
+-  var root = freeGlobal || freeSelf || Function('return this')();
++  /** Used as a reference to the global object without dynamic eval. */
++  var freeGlobalThis = typeof globalThis == 'object' && globalThis &&
++    globalThis.Object === Object && globalThis;
++
++  var root = freeGlobal || freeSelf || freeGlobalThis;
+ 
+   /** Detect free variable `exports`. */
+   var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
+diff --git a/lodash.js b/lodash.js
+index ba61bcba083afe38d65e1a05f714b9be8f3b2ed3..2e56ae4c3faf373febda78d89648d7159fd3e750 100644
+--- a/lodash.js
++++ b/lodash.js
+@@ -432,8 +432,11 @@
+   /** Detect free variable `self`. */
+   var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+ 
+-  /** Used as a reference to the global object. */
+-  var root = freeGlobal || freeSelf || Function('return this')();
++  /** Used as a reference to the global object without dynamic eval. */
++  var freeGlobalThis = typeof globalThis == 'object' && globalThis &&
++    globalThis.Object === Object && globalThis;
++
++  var root = freeGlobal || freeSelf || freeGlobalThis;
+ 
+   /** Detect free variable `exports`. */
+   var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  lodash@4.17.23:
+    hash: 3988be7bdab0757690c4da375c7bea87fa35b3a284f60c7a43503856b9f6af96
+    path: patches/lodash@4.17.23.patch
+
 importers:
 
   .:
@@ -6412,7 +6417,7 @@ snapshots:
       classnames: 2.5.1
       d3-path: 1.0.9
       d3-shape: 1.3.7
-      lodash: 4.17.23
+      lodash: 4.17.23(patch_hash=3988be7bdab0757690c4da375c7bea87fa35b3a284f60c7a43503856b9f6af96)
       prop-types: 15.8.1
       react: 19.2.4
 
@@ -6421,7 +6426,7 @@ snapshots:
       '@types/lodash': 4.17.24
       '@types/react': 19.2.14
       classnames: 2.5.1
-      lodash: 4.17.23
+      lodash: 4.17.23(patch_hash=3988be7bdab0757690c4da375c7bea87fa35b3a284f60c7a43503856b9f6af96)
       prop-types: 15.8.1
       react: 19.2.4
       reduce-css-calc: 1.3.0
@@ -8405,7 +8410,7 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash@4.17.23: {}
+  lodash@4.17.23(patch_hash=3988be7bdab0757690c4da375c7bea87fa35b3a284f60c7a43503856b9f6af96): {}
 
   log-update@6.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ onlyBuiltDependencies:
   - "@tailwindcss/oxide"
   - esbuild
   - spawn-sync ## @v1, dependency of web-ext-run
+patchedDependencies:
+  lodash@4.17.23: patches/lodash@4.17.23.patch
 
 savePrefix: ""
 


### PR DESCRIPTION
Фикс после https://github.com/botnadzor/extension/pull/125. Добавляет точечный pnpm patch для lodash 4.17.23, чтобы убрать eval-подобный fallback через Function("return this")() из цепочки зависимостей контент-скрипта Firefox.

Патч заменяет получение глобального объекта на globalThis и не меняет остальную логику lodash. Это сохраняет текущую реализацию графика на visx и убирает CSP-несовместимый код из собранного content script.

Проверка:
- pnpm build:firefox
- pnpm zip:firefox
- pnpm test:unit src/entrypoints/content/insertion-variants/=account-list/*.test.ts
- в dist/firefox-mv3/content-scripts/content.js отсутствуют вызовы Function(