### PR TITLE
Implement resumable remote staging

### DIFF
--- a/src/entrypoints/background/@services/static-lists-service.ts
+++ b/src/entrypoints/background/@services/static-lists-service.ts
@@ -7,6 +7,8 @@ import { getBackgroundLogger } from "@/shared/@logging/categories";
 import type {
   StaticListCombiningMode,
   StaticListItemOrigin,
+  StaticListRemoteInstance,
+  StaticListUpstreamInfo,
 } from "@/shared/@model/static-list-helpers";
 import type { StaticListMetadata } from "@/shared/@model/static-list-metadata";
 import {
@@ -49,6 +51,12 @@ import {
   tryParseStaticListMetadata,
 } from "./static-lists-service/metadata-helpers";
 import {
+  analyzeRemoteStagingTailRows,
+  reconcileRemoteStagingMetadataWithRowsState,
+  shouldVerifyResumedLine,
+  type StaticListRemoteRowsState,
+} from "./static-lists-service/remote-metadata-helpers";
+import {
   createStoredRemoteRow,
   prepareUnvalidatedLocalRow,
   prepareValidatedLocalRow,
@@ -73,6 +81,7 @@ const logger = getBackgroundLogger(["static-lists-service"]);
 const itemBatchSize = 1000;
 const maxGetItemsCount = 10_000;
 const defaultLocalRowLimit = 1000;
+const resumeVerificationStride = 1000;
 
 type PopulateFromUrlIfOutdatedResult =
   | {
@@ -95,6 +104,15 @@ type ListContext = {
 type PreparedLocalRowResult =
   | { success: true; row: StoredLocalRow }
   | { success: false; error: string; details?: unknown };
+
+type RemoteStagingSession = {
+  activeInstance: StaticListRemoteInstance;
+  mutableStagingSummary: WritableDeep<StaticListSummary>;
+  resumedHeadLineNumber: number;
+  startedAtIso: IsoDateTime;
+  targetInstance: StaticListRemoteInstance;
+  targetTable: Table<StoredRemoteRow, number>;
+};
 
 async function* streamLines(
   readableStream: ReadableStream<Uint8Array>,
@@ -336,6 +354,272 @@ export class StaticListsService {
     return logger.getChild([listId]);
   }
 
+  private async getRemoteRowsState(
+    remoteTable: Table<StoredRemoteRow, number> | undefined,
+  ): Promise<StaticListRemoteRowsState> {
+    if (!remoteTable) {
+      return "missing";
+    }
+
+    return (await remoteTable.count()) === 0 ? "empty" : "present";
+  }
+
+  private async getRemoteHeadLineNumber(
+    remoteTable: Table<StoredRemoteRow, number>,
+  ): Promise<number> {
+    const lastRow = await remoteTable.orderBy("r").last();
+    return lastRow?.r ?? 0;
+  }
+
+  private async getRemoteTailRows(
+    remoteTable: Table<StoredRemoteRow, number>,
+    lineNumberExclusive: number,
+  ): Promise<StoredRemoteRow[]> {
+    return lineNumberExclusive <= 0
+      ? await remoteTable.orderBy("r").toArray()
+      : await remoteTable.where("r").above(lineNumberExclusive).sortBy("r");
+  }
+
+  private async discardRemoteStaging(
+    listId: StaticListId,
+    options?: { deleteRows?: boolean },
+  ): Promise<void> {
+    const context = await this.ensureListContext(listId);
+
+    if (options?.deleteRows !== false) {
+      await context.databases.deleteRemoteDatabase(
+        pickAnotherRemoteInstance(context.metadata.remoteActiveInstance),
+      );
+    }
+
+    if (context.metadata.remoteStaging) {
+      await this.persistMetadata(listId, omitRemoteStaging(context.metadata));
+    }
+  }
+
+  private async promoteRemoteStaging({
+    activeInstance,
+    listId,
+    startedAtIso,
+    summary,
+    targetInstance,
+    upstreamInfo,
+  }: {
+    activeInstance: StaticListRemoteInstance;
+    listId: StaticListId;
+    startedAtIso: IsoDateTime;
+    summary: StaticListSummary;
+    targetInstance: StaticListRemoteInstance;
+    upstreamInfo: StaticListUpstreamInfo;
+  }): Promise<void> {
+    const context = await this.ensureListContext(listId);
+    const finalMetadata = withUpdatedDerivedDataVersion(
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
+      {
+        ...this.getCurrentMetadata(listId),
+        remoteActiveInstance: targetInstance,
+        remoteActive: {
+          startedAt: startedAtIso,
+          updatedAt: isoDateTimeSchema.parse(Date.now()),
+          upstreamInfo,
+          summary: structuredClone(summary),
+        },
+      } as StaticListMetadata,
+    );
+
+    if (shouldComputeDevSummaries(finalMetadata.combiningMode)) {
+      await this.persistMetadata(listId, omitRemoteStaging(finalMetadata), {
+        publish: false,
+      });
+      await this.recomputeDevSummaries(listId);
+    } else {
+      await this.persistMetadata(listId, omitRemoteStaging(finalMetadata));
+    }
+
+    await context.databases.deleteRemoteDatabase(activeInstance);
+  }
+
+  private async createFreshRemoteStaging(
+    listId: StaticListId,
+    upstreamInfo: StaticListUpstreamInfo,
+  ): Promise<RemoteStagingSession> {
+    const context = await this.ensureListContext(listId);
+    const startedAtIso = isoDateTimeSchema.parse(Date.now());
+    const targetInstance = pickAnotherRemoteInstance(
+      context.metadata.remoteActiveInstance,
+    );
+    const activeInstance = context.metadata.remoteActiveInstance;
+    const targetDatabase =
+      await context.databases.resetRemoteDatabase(targetInstance);
+    const mutableStagingSummary: WritableDeep<StaticListSummary> =
+      cloneEmptySummary(listId);
+
+    await this.persistMetadata(
+      listId,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
+      {
+        ...context.metadata,
+        remoteStaging: {
+          durableLineNumber: 0,
+          startedAt: startedAtIso,
+          updatedAt: startedAtIso,
+          upstreamInfo,
+          summary: structuredClone(mutableStagingSummary),
+        },
+      } as StaticListMetadata,
+    );
+
+    return {
+      activeInstance,
+      mutableStagingSummary,
+      resumedHeadLineNumber: 0,
+      startedAtIso,
+      targetInstance,
+      targetTable: targetDatabase.rows,
+    };
+  }
+
+  private async tryResumeRemoteStaging(
+    listId: StaticListId,
+    upstreamInfo: StaticListUpstreamInfo,
+  ): Promise<RemoteStagingSession | undefined> {
+    const context = await this.ensureListContext(listId);
+    const listLogger = this.getListLogger(listId);
+    const remoteStaging = context.metadata.remoteStaging;
+    if (!remoteStaging) {
+      return;
+    }
+
+    if (
+      remoteStaging.upstreamInfo.generatedAt !== upstreamInfo.generatedAt ||
+      remoteStaging.upstreamInfo.itemCount !== upstreamInfo.itemCount
+    ) {
+      listLogger.info(
+        "Discarding staging because upstream info changed ({oldGeneratedAt}/{oldItemCount} -> {newGeneratedAt}/{newItemCount})",
+        {
+          newGeneratedAt: upstreamInfo.generatedAt,
+          newItemCount: upstreamInfo.itemCount,
+          oldGeneratedAt: remoteStaging.upstreamInfo.generatedAt,
+          oldItemCount: remoteStaging.upstreamInfo.itemCount,
+        },
+      );
+      await this.discardRemoteStaging(listId);
+      return;
+    }
+
+    if (remoteStaging.durableLineNumber === undefined) {
+      listLogger.info(
+        "Discarding staging because durable cursor is missing in persisted metadata",
+      );
+      await this.discardRemoteStaging(listId);
+      return;
+    }
+
+    const targetInstance = pickAnotherRemoteInstance(
+      context.metadata.remoteActiveInstance,
+    );
+    const targetTable = await context.databases.getRemoteRows(targetInstance, {
+      createIfMissing: false,
+    });
+    const remoteRowsState = await this.getRemoteRowsState(targetTable);
+
+    if (remoteRowsState !== "present" || !targetTable) {
+      listLogger.info(
+        "Discarding staging because resumable rows are no longer present ({remoteRowsState})",
+        { remoteRowsState },
+      );
+      await this.discardRemoteStaging(listId, {
+        deleteRows: remoteRowsState !== "missing",
+      });
+      return;
+    }
+
+    const resumedHeadLineNumber =
+      await this.getRemoteHeadLineNumber(targetTable);
+    if (resumedHeadLineNumber > upstreamInfo.itemCount) {
+      listLogger.info(
+        "Discarding staging because staged rows exceed upstream item count ({resumedHeadLineNumber} > {itemCount})",
+        {
+          itemCount: upstreamInfo.itemCount,
+          resumedHeadLineNumber,
+        },
+      );
+      await this.discardRemoteStaging(listId);
+      return;
+    }
+
+    const tailRows = await this.getRemoteTailRows(
+      targetTable,
+      remoteStaging.durableLineNumber,
+    );
+    const tailAnalysis = analyzeRemoteStagingTailRows({
+      durableLineNumber: remoteStaging.durableLineNumber,
+      headLineNumber: resumedHeadLineNumber,
+      tailLineNumbers: tailRows.map((row) => row.r),
+    });
+
+    if (!tailAnalysis.success) {
+      listLogger.info(
+        "Discarding staging because persisted tail is invalid ({reason})",
+        { reason: tailAnalysis.reason },
+      );
+      await this.discardRemoteStaging(listId);
+      return;
+    }
+
+    const mutableStagingSummary: WritableDeep<StaticListSummary> =
+      structuredClone(
+        extractSummaryFromMetadata(context.metadata, "remoteStaging"),
+      );
+
+    for (const tailRow of tailRows) {
+      const interpretedRow = interpretStoredRow(listId, tailRow, "remote");
+      if (interpretedRow.interpretation.success) {
+        context.definitionInfo.definition.adjustSummary(
+          mutableStagingSummary,
+          interpretedRow.interpretation.item,
+          1,
+        );
+      }
+    }
+
+    if (tailRows.length > 0) {
+      await this.persistMetadata(
+        listId,
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
+        {
+          ...this.getCurrentMetadata(listId),
+          remoteStaging: {
+            ...remoteStaging,
+            durableLineNumber: resumedHeadLineNumber,
+            summary: structuredClone(mutableStagingSummary),
+            updatedAt: isoDateTimeSchema.parse(Date.now()),
+          },
+        } as StaticListMetadata,
+      );
+
+      listLogger.info(
+        "Recovered staging summary tail for {repairedLineCount} row(s) before resume",
+        {
+          repairedLineCount: tailAnalysis.repairedLineCount,
+        },
+      );
+    }
+
+    listLogger.info("Resuming staging from line {resumedHeadLineNumber}", {
+      resumedHeadLineNumber,
+    });
+
+    return {
+      activeInstance: context.metadata.remoteActiveInstance,
+      mutableStagingSummary,
+      resumedHeadLineNumber,
+      startedAtIso: remoteStaging.startedAt,
+      targetInstance,
+      targetTable,
+    };
+  }
+
   /**
    * Initialization is where we reconcile persisted metadata with the actual
    * databases on disk.
@@ -417,20 +701,49 @@ export class StaticListsService {
       await metadataStore.setValue(metadata);
     }
 
-    const readableMetadata = metadata;
+    const inactiveRemoteInstance = pickAnotherRemoteInstance(
+      metadata.remoteActiveInstance,
+    );
+    const inactiveRemoteTable = await databases.getRemoteRows(
+      inactiveRemoteInstance,
+      { createIfMissing: false },
+    );
+    const remoteStagingRecovery = reconcileRemoteStagingMetadataWithRowsState(
+      metadata,
+      await this.getRemoteRowsState(inactiveRemoteTable),
+    );
+    metadata = remoteStagingRecovery.metadata;
 
-    if (readableMetadata.remoteStaging) {
-      listLogger.warn(
-        "Abandoned remote staging detected, clearing inactive store",
-      );
+    switch (remoteStagingRecovery.recovery) {
+      case "missing": {
+        listLogger.warn(
+          "Remote staging metadata exists but the inactive remote database is missing, clearing staging metadata",
+        );
+        await metadataStore.setValue(metadata);
+        break;
+      }
 
-      await databases.deleteRemoteDatabase(
-        pickAnotherRemoteInstance(readableMetadata.remoteActiveInstance),
-      );
+      case "empty": {
+        listLogger.warn(
+          "Inactive remote database is empty, clearing staging metadata and deleting the empty database",
+        );
+        await databases.deleteRemoteDatabase(inactiveRemoteInstance);
+        await metadataStore.setValue(metadata);
+        break;
+      }
 
-      metadata = omitRemoteStaging(readableMetadata);
+      case "orphaned": {
+        listLogger.warn(
+          "Inactive remote database exists without staging metadata, deleting orphaned staging rows",
+        );
+        await databases.deleteRemoteDatabase(inactiveRemoteInstance);
+        break;
+      }
 
-      await metadataStore.setValue(metadata);
+      case "present":
+      case undefined: {
+        break;
+      }
     }
 
     if (metadata.localUpdatedAt) {
@@ -1083,169 +1396,208 @@ export class StaticListsService {
       return { success: true, data: "updateNotNeeded" };
     }
 
-    const startedAt = Date.now();
-    const startedAtIso = isoDateTimeSchema.parse(startedAt);
-    const targetInstance = pickAnotherRemoteInstance(
-      context.metadata.remoteActiveInstance,
-    );
-    const activeInstance = context.metadata.remoteActiveInstance;
-    const targetDatabase =
-      await context.databases.resetRemoteDatabase(targetInstance);
-    const targetTable = targetDatabase.rows;
-    const mutableStagingSummary: WritableDeep<StaticListSummary> =
-      cloneEmptySummary(listId);
+    let shouldForceFreshRestart = false;
 
-    await this.persistMetadata(
-      listId,
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
-      {
-        ...context.metadata,
-        remoteStaging: {
-          startedAt: startedAtIso,
-          updatedAt: startedAtIso,
-          upstreamInfo,
-          summary: structuredClone(mutableStagingSummary),
-        },
-      } as StaticListMetadata,
-    );
+    for (;;) {
+      const stagingSession = shouldForceFreshRestart
+        ? await this.createFreshRemoteStaging(listId, upstreamInfo)
+        : ((await this.tryResumeRemoteStaging(listId, upstreamInfo)) ??
+          (await this.createFreshRemoteStaging(listId, upstreamInfo)));
 
-    try {
-      const fetchResult = await fetchFromRemoteSystem({
-        aliasManager: this.aliasManagerForStaticApi,
-        urlSuffix: `/lists/${listId}.jsonl`,
-      });
+      const {
+        activeInstance,
+        mutableStagingSummary,
+        resumedHeadLineNumber,
+        startedAtIso,
+        targetInstance,
+        targetTable,
+      } = stagingSession;
 
-      if (!fetchResult.success) {
-        return {
-          success: false,
-          error: `Failed to fetch list from static API (reason: ${fetchResult.reason})`,
-        };
-      }
-
-      if (fetchResult.response.status !== 200) {
-        return {
-          success: false,
-          error: `Failed to fetch list from static API: ${fetchResult.response.status}`,
-        };
-      }
-
-      if (!fetchResult.response.body) {
-        return { success: false, error: "No response body from static API" };
-      }
-
-      let lineNumber = 0;
-      let storedBatchCount = 0;
-      let storedRowCount = 0;
-      let rowsToStore: StoredRemoteRow[] = [];
-
-      const flushBatch = async (shouldPersistStagingProgress: boolean) => {
-        if (rowsToStore.length === 0) {
-          return;
-        }
-
-        storedBatchCount += 1;
-        storedRowCount += rowsToStore.length;
-        await targetTable.bulkPut(rowsToStore);
-        rowsToStore = [];
-
-        if (!shouldPersistStagingProgress) {
-          return;
-        }
-
-        const currentMetadata = this.getCurrentMetadata(listId);
-        if (!currentMetadata.remoteStaging) {
-          return;
-        }
-
-        await this.persistMetadata(
-          listId,
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
-          {
-            ...currentMetadata,
-            remoteStaging: {
-              ...currentMetadata.remoteStaging,
-              updatedAt: isoDateTimeSchema.parse(Date.now()),
-              summary: structuredClone(mutableStagingSummary),
-            },
-          } as StaticListMetadata,
-        );
-      };
-
-      for await (const line of streamLines(fetchResult.response.body)) {
-        lineNumber += 1;
-        const storedRow = createStoredRemoteRow({
-          listId,
-          lineNumber,
-          sourceText: line,
+      try {
+        const fetchResult = await fetchFromRemoteSystem({
+          aliasManager: this.aliasManagerForStaticApi,
+          urlSuffix: `/lists/${listId}.jsonl`,
         });
 
-        rowsToStore.push(storedRow);
+        if (!fetchResult.success) {
+          return {
+            success: false,
+            error: `Failed to fetch list from static API (reason: ${fetchResult.reason})`,
+          };
+        }
 
-        const interpretedRow = interpretStoredRow(listId, storedRow, "remote");
-        if (interpretedRow.interpretation.success) {
-          context.definitionInfo.definition.adjustSummary(
-            mutableStagingSummary,
-            interpretedRow.interpretation.item,
-            1,
+        if (fetchResult.response.status !== 200) {
+          return {
+            success: false,
+            error: `Failed to fetch list from static API: ${fetchResult.response.status}`,
+          };
+        }
+
+        if (!fetchResult.response.body) {
+          return { success: false, error: "No response body from static API" };
+        }
+
+        let lineNumber = 0;
+        let storedBatchCount = 0;
+        let storedRowCount = 0;
+        let rowsToStore: StoredRemoteRow[] = [];
+        let restartFreshReason: string | undefined;
+
+        const flushBatch = async (shouldPersistStagingProgress: boolean) => {
+          if (rowsToStore.length === 0) {
+            return;
+          }
+
+          const durableLineNumber = rowsToStore.at(-1)?.r ?? 0;
+          storedBatchCount += 1;
+          storedRowCount += rowsToStore.length;
+          await targetTable.bulkPut(rowsToStore);
+          rowsToStore = [];
+
+          if (!shouldPersistStagingProgress) {
+            return;
+          }
+
+          const currentMetadata = this.getCurrentMetadata(listId);
+          if (!currentMetadata.remoteStaging) {
+            return;
+          }
+
+          await this.persistMetadata(
+            listId,
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
+            {
+              ...currentMetadata,
+              remoteStaging: {
+                ...currentMetadata.remoteStaging,
+                durableLineNumber,
+                updatedAt: isoDateTimeSchema.parse(Date.now()),
+                summary: structuredClone(mutableStagingSummary),
+              },
+            } as StaticListMetadata,
+          );
+        };
+
+        for await (const line of streamLines(fetchResult.response.body)) {
+          lineNumber += 1;
+
+          if (lineNumber <= resumedHeadLineNumber) {
+            if (
+              !shouldVerifyResumedLine({
+                durableLineNumber: resumedHeadLineNumber,
+                lineNumber,
+                stride: resumeVerificationStride,
+              })
+            ) {
+              continue;
+            }
+
+            const stagedRow = await targetTable
+              .where("r")
+              .equals(lineNumber)
+              .first();
+
+            if (!stagedRow) {
+              restartFreshReason = `Missing staged row at line ${lineNumber}`;
+              break;
+            }
+
+            if (stagedRow.t !== line) {
+              restartFreshReason = `Staged row content mismatch at line ${lineNumber}`;
+              break;
+            }
+
+            continue;
+          }
+
+          const storedRow = createStoredRemoteRow({
+            listId,
+            lineNumber,
+            sourceText: line,
+          });
+
+          rowsToStore.push(storedRow);
+
+          const interpretedRow = interpretStoredRow(
+            listId,
+            storedRow,
+            "remote",
+          );
+          if (interpretedRow.interpretation.success) {
+            context.definitionInfo.definition.adjustSummary(
+              mutableStagingSummary,
+              interpretedRow.interpretation.item,
+              1,
+            );
+          }
+
+          if (rowsToStore.length >= itemBatchSize) {
+            await flushBatch(true);
+          }
+        }
+
+        if (!restartFreshReason && lineNumber < resumedHeadLineNumber) {
+          restartFreshReason = `Remote list ended at line ${lineNumber} before staged prefix ${resumedHeadLineNumber}`;
+        }
+
+        if (
+          !restartFreshReason &&
+          resumedHeadLineNumber === upstreamInfo.itemCount &&
+          lineNumber !== resumedHeadLineNumber
+        ) {
+          restartFreshReason = `Remote list length changed during direct promotion verification (${lineNumber} !== ${resumedHeadLineNumber})`;
+        }
+
+        if (restartFreshReason) {
+          listLogger.warn(
+            "Selective resume verification failed, discarding staging and retrying fresh: {reason}",
+            { reason: restartFreshReason },
+          );
+          await this.discardRemoteStaging(listId);
+
+          if (shouldForceFreshRestart) {
+            return { success: false, error: restartFreshReason };
+          }
+
+          shouldForceFreshRestart = true;
+          continue;
+        }
+
+        await flushBatch(false);
+
+        await this.promoteRemoteStaging({
+          activeInstance,
+          listId,
+          startedAtIso,
+          summary: mutableStagingSummary,
+          targetInstance,
+          upstreamInfo,
+        });
+
+        if (resumedHeadLineNumber > 0 && storedRowCount === 0) {
+          listLogger.info(
+            "Verified and promoted completed staging without downloading new rows",
+          );
+        } else {
+          listLogger.info(
+            "Populated {storedRowCount} remote rows (batches: {storedBatchCount}, resumedFromLine: {resumedHeadLineNumber})",
+            {
+              resumedHeadLineNumber,
+              storedBatchCount,
+              storedRowCount,
+            },
           );
         }
 
-        if (rowsToStore.length >= itemBatchSize) {
-          await flushBatch(true);
-        }
-      }
-
-      await flushBatch(false);
-
-      const finishedAtIso = isoDateTimeSchema.parse(Date.now());
-      const finalMetadata = withUpdatedDerivedDataVersion(
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
-        {
-          ...this.getCurrentMetadata(listId),
-          remoteActiveInstance: targetInstance,
-          remoteActive: {
-            startedAt: startedAtIso,
-            updatedAt: finishedAtIso,
-            upstreamInfo,
-            summary: structuredClone(mutableStagingSummary),
-          },
-        } as StaticListMetadata,
-      );
-
-      if (shouldComputeDevSummaries(finalMetadata.combiningMode)) {
-        await this.persistMetadata(listId, omitRemoteStaging(finalMetadata), {
-          publish: false,
+        return { success: true, data: "updated" };
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        listLogger.error("Unexpected error while populating: {error}", {
+          error: errorMessage,
         });
-        await this.recomputeDevSummaries(listId);
-      } else {
-        await this.persistMetadata(listId, omitRemoteStaging(finalMetadata));
+
+        return { success: false, error: errorMessage };
       }
-
-      await context.databases.deleteRemoteDatabase(activeInstance);
-
-      listLogger.info(
-        "Populated {storedRowCount} remote rows (batches: {storedBatchCount})",
-        {
-          storedBatchCount,
-          storedRowCount,
-        },
-      );
-
-      return { success: true, data: "updated" };
-    } catch (error) {
-      await context.databases.deleteRemoteDatabase(targetInstance);
-
-      const metadata = this.getCurrentMetadata(listId);
-      if (metadata.remoteStaging) {
-        await this.persistMetadata(listId, omitRemoteStaging(metadata));
-      }
-
-      const errorMessage = getErrorMessage(error);
-      listLogger.error("Unexpected error while populating: {error}", {
-        error: errorMessage,
-      });
-
-      return { success: false, error: errorMessage };
     }
   }
 

--- a/src/entrypoints/background/@services/static-lists-service/remote-metadata-helpers.test.ts
+++ b/src/entrypoints/background/@services/static-lists-service/remote-metadata-helpers.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
+
+import {
+  analyzeRemoteStagingTailRows,
+  reconcileRemoteStagingMetadataWithRowsState,
+  shouldVerifyResumedLine,
+} from "./remote-metadata-helpers";
+
+function metadataWithRemoteStaging() {
+  return {
+    listId: "announcements" as const,
+    physicalStorageVersion: 1,
+    derivedDataVersion: "test",
+    combiningMode: "remoteOnly" as const,
+    remoteActiveInstance: "b" as const,
+    remoteStaging: {
+      durableLineNumber: 25,
+      startedAt: isoDateTimeSchema.parse("2026-03-28T14:45:24.883Z"),
+      summary: { itemCount: 25 },
+      updatedAt: isoDateTimeSchema.parse("2026-03-28T14:45:25.883Z"),
+      upstreamInfo: {
+        generatedAt: isoDateTimeSchema.parse("2026-03-28T14:45:24.883Z"),
+        itemCount: 100,
+      },
+    },
+  };
+}
+
+describe("reconcileRemoteStagingMetadataWithRowsState", () => {
+  it("preserves staging when metadata and rows are present", () => {
+    const metadata = metadataWithRemoteStaging();
+
+    const result = reconcileRemoteStagingMetadataWithRowsState(
+      metadata,
+      "present",
+    );
+
+    expect(result.recovery).toBeUndefined();
+    expect(result.metadata).toEqual(metadata);
+  });
+
+  it("clears stale staging metadata when rows are missing", () => {
+    const result = reconcileRemoteStagingMetadataWithRowsState(
+      metadataWithRemoteStaging(),
+      "missing",
+    );
+
+    expect(result.recovery).toBe("missing");
+    expect(Object.hasOwn(result.metadata, "remoteStaging")).toBe(false);
+  });
+
+  it("clears stale staging metadata when rows are empty", () => {
+    const result = reconcileRemoteStagingMetadataWithRowsState(
+      metadataWithRemoteStaging(),
+      "empty",
+    );
+
+    expect(result.recovery).toBe("empty");
+    expect(Object.hasOwn(result.metadata, "remoteStaging")).toBe(false);
+  });
+
+  it("marks present rows without metadata as orphaned", () => {
+    const result = reconcileRemoteStagingMetadataWithRowsState(
+      {
+        listId: "announcements" as const,
+        physicalStorageVersion: 1,
+        derivedDataVersion: "test",
+        combiningMode: "remoteOnly" as const,
+        remoteActiveInstance: "b" as const,
+      },
+      "present",
+    );
+
+    expect(result.recovery).toBe("orphaned");
+  });
+});
+
+describe("analyzeRemoteStagingTailRows", () => {
+  it("accepts a fully synced durable cursor", () => {
+    expect(
+      analyzeRemoteStagingTailRows({
+        durableLineNumber: 100,
+        headLineNumber: 100,
+        tailLineNumbers: [],
+      }),
+    ).toEqual({ success: true, repairedLineCount: 0 });
+  });
+
+  it("accepts a small contiguous tail ahead of metadata", () => {
+    expect(
+      analyzeRemoteStagingTailRows({
+        durableLineNumber: 100,
+        headLineNumber: 103,
+        tailLineNumbers: [101, 102, 103],
+      }),
+    ).toEqual({ success: true, repairedLineCount: 3 });
+  });
+
+  it("rejects durable metadata ahead of rows", () => {
+    expect(
+      analyzeRemoteStagingTailRows({
+        durableLineNumber: 101,
+        headLineNumber: 100,
+        tailLineNumbers: [],
+      }),
+    ).toEqual({ success: false, reason: "durableAheadOfRows" });
+  });
+
+  it("rejects non-contiguous repair tails", () => {
+    expect(
+      analyzeRemoteStagingTailRows({
+        durableLineNumber: 100,
+        headLineNumber: 103,
+        tailLineNumbers: [101, 103],
+      }),
+    ).toEqual({ success: false, reason: "nonContiguousTail" });
+  });
+});
+
+describe("shouldVerifyResumedLine", () => {
+  const durableLineNumber = 2500;
+  const stride = 1000;
+
+  it("always verifies the first line", () => {
+    expect(
+      shouldVerifyResumedLine({ durableLineNumber, lineNumber: 1, stride }),
+    ).toBe(true);
+  });
+
+  it("verifies configured stride checkpoints", () => {
+    expect(
+      shouldVerifyResumedLine({ durableLineNumber, lineNumber: 1000, stride }),
+    ).toBe(true);
+  });
+
+  it("always verifies the durable boundary line", () => {
+    expect(
+      shouldVerifyResumedLine({
+        durableLineNumber,
+        lineNumber: durableLineNumber,
+        stride,
+      }),
+    ).toBe(true);
+  });
+
+  it("skips unsampled interior lines", () => {
+    expect(
+      shouldVerifyResumedLine({ durableLineNumber, lineNumber: 999, stride }),
+    ).toBe(false);
+  });
+
+  it("ignores lines beyond the resumed prefix", () => {
+    expect(
+      shouldVerifyResumedLine({
+        durableLineNumber,
+        lineNumber: durableLineNumber + 1,
+        stride,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/entrypoints/background/@services/static-lists-service/remote-metadata-helpers.ts
+++ b/src/entrypoints/background/@services/static-lists-service/remote-metadata-helpers.ts
@@ -1,0 +1,106 @@
+import type { StaticListMetadata } from "@/shared/@model/static-list-metadata";
+import type { StaticListId } from "@/shared/@model/static-lists";
+
+export function omitRemoteStaging<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+): StaticListMetadata<ListId> {
+  const { remoteStaging: remoteStagingOmitted, ...metadataWithoutRemote } =
+    metadata;
+  void remoteStagingOmitted;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- removing an exact-optional property via rest is correct at runtime but TS loses that shape
+  return metadataWithoutRemote as StaticListMetadata<ListId>;
+}
+
+export type StaticListRemoteRowsState = "missing" | "empty" | "present";
+
+export function reconcileRemoteStagingMetadataWithRowsState<
+  ListId extends StaticListId,
+>(
+  metadata: StaticListMetadata<ListId>,
+  remoteRowsState: StaticListRemoteRowsState,
+): {
+  metadata: StaticListMetadata<ListId>;
+  recovery?: StaticListRemoteRowsState | "orphaned";
+} {
+  if (metadata.remoteStaging) {
+    if (remoteRowsState === "present") {
+      return { metadata };
+    }
+
+    return {
+      metadata: omitRemoteStaging(metadata),
+      recovery: remoteRowsState,
+    };
+  }
+
+  if (remoteRowsState === "missing") {
+    return { metadata };
+  }
+
+  return { metadata, recovery: "orphaned" };
+}
+
+export function shouldVerifyResumedLine({
+  durableLineNumber,
+  lineNumber,
+  stride,
+}: {
+  durableLineNumber: number;
+  lineNumber: number;
+  stride: number;
+}): boolean {
+  if (
+    durableLineNumber <= 0 ||
+    lineNumber <= 0 ||
+    lineNumber > durableLineNumber
+  ) {
+    return false;
+  }
+
+  return (
+    lineNumber === 1 ||
+    lineNumber === durableLineNumber ||
+    lineNumber % stride === 0
+  );
+}
+
+export function analyzeRemoteStagingTailRows({
+  durableLineNumber,
+  headLineNumber,
+  tailLineNumbers,
+}: {
+  durableLineNumber: number;
+  headLineNumber: number;
+  tailLineNumbers: number[];
+}):
+  | {
+      success: true;
+      repairedLineCount: number;
+    }
+  | {
+      success: false;
+      reason: "durableAheadOfRows" | "nonContiguousTail";
+    } {
+  if (durableLineNumber > headLineNumber) {
+    return { success: false, reason: "durableAheadOfRows" };
+  }
+
+  let expectedLineNumber = durableLineNumber + 1;
+
+  for (const lineNumber of tailLineNumbers) {
+    if (lineNumber !== expectedLineNumber) {
+      return { success: false, reason: "nonContiguousTail" };
+    }
+
+    expectedLineNumber += 1;
+  }
+
+  if (expectedLineNumber - 1 !== headLineNumber) {
+    return { success: false, reason: "nonContiguousTail" };
+  }
+
+  return {
+    success: true,
+    repairedLineCount: headLineNumber - durableLineNumber,
+  };
+}

--- a/src/shared/@model/static-list-metadata.ts
+++ b/src/shared/@model/static-list-metadata.ts
@@ -40,6 +40,9 @@ export const staticListMetadataSchema = z.readonly(
     remoteStaging: z.exactOptional(
       z.readonly(
         z.object({
+          durableLineNumber: z.exactOptional(
+            z.number().check(z.int(), z.nonnegative()),
+          ),
           startedAt: isoDateTimeSchema,
           summary: z.json(),
           updatedAt: isoDateTimeSchema,
@@ -55,12 +58,23 @@ export type StoredStaticListMetadata = z.infer<typeof staticListMetadataSchema>;
 type StoredStaticListMetadataRemoteState = NonNullable<
   StoredStaticListMetadata["remoteActive"]
 >;
-
-type StaticListMetadataRemoteState<ListId extends StaticListId> = Readonly<
-  Omit<StoredStaticListMetadataRemoteState, "summary"> & {
-    summary: StaticListSummary<ListId>;
-  }
+type StoredStaticListMetadataRemoteStagingState = NonNullable<
+  StoredStaticListMetadata["remoteStaging"]
 >;
+
+type StaticListMetadataRemoteActiveState<ListId extends StaticListId> =
+  Readonly<
+    Omit<StoredStaticListMetadataRemoteState, "summary"> & {
+      summary: StaticListSummary<ListId>;
+    }
+  >;
+
+type StaticListMetadataRemoteStagingState<ListId extends StaticListId> =
+  Readonly<
+    Omit<StoredStaticListMetadataRemoteStagingState, "summary"> & {
+      summary: StaticListSummary<ListId>;
+    }
+  >;
 
 type StaticListMetadataBase = Omit<
   StoredStaticListMetadata,
@@ -71,8 +85,8 @@ type StaticListMetadataByListId = {
   [ListId in StaticListId]: Readonly<
     StaticListMetadataBase & {
       listId: ListId;
-      remoteActive?: StaticListMetadataRemoteState<ListId>;
-      remoteStaging?: StaticListMetadataRemoteState<ListId>;
+      remoteActive?: StaticListMetadataRemoteActiveState<ListId>;
+      remoteStaging?: StaticListMetadataRemoteStagingState<ListId>;
     }
   >;
 };


### PR DESCRIPTION
Добавлена возобновляемая загрузка remote staging для статических списков с сохранением durableLineNumber в метаданных.

При перезапуске background сервис теперь восстанавливает staging из IndexedDB, чинит хвост, если база опережает метаданные, и продолжает загрузку без сброса уже сохранённых строк.

Для защиты от редких рассинхронизаций между root-config и фактическим содержимым JSONL добавлена выборочная проверка пропускаемого префикса. При обнаружении несовпадения staging сбрасывается и пересобирается с нуля.

Также добавлены отдельные helper-функции и unit-тесты для логики восстановления remote staging.