### PR TITLE
Refine legacy v1 cleanup logging

### DIFF
--- a/src/entrypoints/background/@services/legacy-v1-migration-helpers.test.ts
+++ b/src/entrypoints/background/@services/legacy-v1-migration-helpers.test.ts
@@ -1,14 +1,114 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthInput } from "@/shared/@model/auth";
 import { defaultUserConfig } from "@/shared/@model/user-config";
 import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
+import { browser } from "#imports";
 
 import {
+  cleanupLegacyV1State,
+  legacyLocalStorageKeys,
   migrateAuthInputFromLegacyTokenState,
   migrateUserConfigFromLegacyState,
   parseLegacyUserSettings,
 } from "./legacy-v1-migration-helpers";
+
+const { indexedDbMock, loggerMock, testState } = vi.hoisted(() => {
+  const hoistedState = {
+    indexedDbNames: new Set<string>(),
+  };
+
+  const hoistedLoggerMock = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  class MockOpenDbRequest extends EventTarget implements IDBOpenDBRequest {
+    // eslint-disable-next-line unicorn/no-null -- IndexedDB request handler fields use null when absent in DOM typings.
+    error: DOMException | null = null;
+    onblocked:
+      | ((this: IDBOpenDBRequest, ev: IDBVersionChangeEvent) => unknown)
+      // eslint-disable-next-line unicorn/no-null -- IndexedDB request handler fields use null when absent in DOM typings.
+      | null = null;
+    onerror: ((this: IDBRequest<IDBDatabase>, ev: Event) => unknown) | null =
+      // eslint-disable-next-line unicorn/no-null -- IndexedDB request handler fields use null when absent in DOM typings.
+      null;
+    onsuccess: ((this: IDBRequest<IDBDatabase>, ev: Event) => unknown) | null =
+      // eslint-disable-next-line unicorn/no-null -- IndexedDB request handler fields use null when absent in DOM typings.
+      null;
+    onupgradeneeded:
+      | ((this: IDBOpenDBRequest, ev: IDBVersionChangeEvent) => unknown)
+      // eslint-disable-next-line unicorn/no-null -- IndexedDB request handler fields use null when absent in DOM typings.
+      | null = null;
+    readyState: IDBRequestReadyState = "done";
+
+    get result(): IDBDatabase {
+      throw new Error("MockOpenDbRequest.result should not be accessed");
+    }
+
+    get source(): IDBObjectStore | IDBIndex | IDBCursor {
+      throw new Error("MockOpenDbRequest.source should not be accessed");
+    }
+
+    get transaction(): IDBTransaction {
+      throw new Error("MockOpenDbRequest.transaction should not be accessed");
+    }
+  }
+
+  const hoistedIndexedDbMock = {
+    databases: vi.fn(() =>
+      Promise.resolve(
+        [...hoistedState.indexedDbNames].map((name) => ({
+          name,
+        })),
+      ),
+    ),
+    deleteDatabase: vi.fn((databaseName: string) => {
+      const request = new MockOpenDbRequest();
+
+      queueMicrotask(() => {
+        hoistedState.indexedDbNames.delete(databaseName);
+
+        request.dispatchEvent(new Event("success"));
+      });
+
+      return request;
+    }),
+  };
+
+  return {
+    indexedDbMock: hoistedIndexedDbMock,
+    loggerMock: hoistedLoggerMock,
+    testState: hoistedState,
+  };
+});
+
+vi.mock("@/shared/@logging/categories", () => ({
+  getBackgroundLogger: () => loggerMock,
+}));
+
+// cspell:ignore gosvon
+
+beforeEach(async () => {
+  testState.indexedDbNames.clear();
+
+  loggerMock.debug.mockReset();
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+  indexedDbMock.databases.mockClear();
+  indexedDbMock.deleteDatabase.mockClear();
+
+  await browser.alarms.clear("10 minutes");
+  await browser.alarms.clear("weekly");
+  await browser.storage.local.remove([...legacyLocalStorageKeys]);
+
+  Object.defineProperty(globalThis, "indexedDB", {
+    configurable: true,
+    value: indexedDbMock,
+    writable: true,
+  });
+});
 
 function authInput(accessCode: string): AuthInput {
   return {
@@ -122,5 +222,62 @@ describe("migrateUserConfigFromLegacyState", () => {
       fansDisplay: "default",
       collectingComments: true,
     });
+  });
+});
+
+describe("cleanupLegacyV1State", () => {
+  it("should log info when at least one legacy artifact was removed", async () => {
+    await browser.storage.local.set({
+      config: { legacy: true },
+    });
+    await browser.alarms.create("weekly", {
+      delayInMinutes: 1,
+    });
+    testState.indexedDbNames.add("gosvon");
+
+    await cleanupLegacyV1State();
+
+    expect(loggerMock.info).toHaveBeenCalledWith("Legacy v1 cleanup completed");
+    expect(loggerMock.debug).not.toHaveBeenCalled();
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+
+    const remainingLegacyState = await browser.storage.local.get("config");
+    expect(remainingLegacyState["config"]).toBeUndefined();
+    expect(await browser.alarms.get("weekly")).toBeUndefined();
+    expect(testState.indexedDbNames.has("gosvon")).toBe(false);
+  });
+
+  it("should log debug when no legacy cleanup was needed", async () => {
+    await cleanupLegacyV1State();
+
+    expect(loggerMock.debug).toHaveBeenCalledWith(
+      "Legacy v1 cleanup was not needed",
+    );
+    expect(loggerMock.info).not.toHaveBeenCalled();
+    expect(loggerMock.warn).not.toHaveBeenCalled();
+  });
+
+  it("should warn when cleanup leaves legacy artifacts behind", async () => {
+    await browser.storage.local.set({
+      config: { legacy: true },
+    });
+
+    const removeLocalStorageValuesSpy = vi
+      .spyOn(browser.storage.local, "remove")
+      .mockImplementation(() => undefined);
+
+    await cleanupLegacyV1State();
+    removeLocalStorageValuesSpy.mockRestore();
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "Legacy v1 cleanup remains incomplete (localStorageRemoved={localStorageRemoved}, alarmsCleared={alarmsCleared}, indexedDbDeleted={indexedDbDeleted})",
+      {
+        alarmsCleared: true,
+        indexedDbDeleted: true,
+        localStorageRemoved: false,
+      },
+    );
+    expect(loggerMock.debug).not.toHaveBeenCalled();
+    expect(loggerMock.info).not.toHaveBeenCalled();
   });
 });

--- a/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
+++ b/src/entrypoints/background/@services/legacy-v1-migration-helpers.ts
@@ -71,6 +71,15 @@ type GlobalNotificationsMigrationState = Readonly<{
   welcomeMessageReadAt: IsoDateTime;
 }>;
 
+type LegacyCleanupStepResult = Readonly<{
+  removedArtifactCount: number;
+  success: boolean;
+}>;
+
+type IndexedDbFactoryWithDatabases = IDBFactory & {
+  databases: () => Promise<ReadonlyArray<{ name?: string }>>;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -167,6 +176,12 @@ function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function canListIndexedDbDatabases(
+  indexedDbFactory: IDBFactory,
+): indexedDbFactory is IndexedDbFactoryWithDatabases {
+  return "databases" in indexedDbFactory;
+}
+
 async function getLocalStorageValues(
   keys: string | readonly string[],
 ): Promise<Record<string, unknown>> {
@@ -179,6 +194,13 @@ async function removeLocalStorageValues(
   keys: readonly string[],
 ): Promise<void> {
   await browser.storage.local.remove([...keys]);
+}
+
+function hasLocalStorageValue(
+  values: Record<string, unknown>,
+  key: string,
+): boolean {
+  return values[key] !== undefined;
 }
 
 async function clearAlarm(alarmName: string): Promise<boolean> {
@@ -384,45 +406,127 @@ export async function migrateGlobalNotificationsStateFromV1(): Promise<
   };
 }
 
-async function removeLegacyLocalStorageKeys(): Promise<boolean> {
+async function removeLegacyLocalStorageKeys(): Promise<LegacyCleanupStepResult> {
+  let currentValues: Record<string, unknown>;
   let remaining: Record<string, unknown>;
   try {
+    currentValues = await getLocalStorageValues([...legacyLocalStorageKeys]);
+    const presentKeys = legacyLocalStorageKeys.filter((key) =>
+      hasLocalStorageValue(currentValues, key),
+    );
+
+    if (presentKeys.length === 0) {
+      return {
+        removedArtifactCount: 0,
+        success: true,
+      };
+    }
+
     await removeLocalStorageValues(legacyLocalStorageKeys);
     remaining = await getLocalStorageValues([...legacyLocalStorageKeys]);
+
+    return {
+      removedArtifactCount: presentKeys.filter(
+        (key) => !hasLocalStorageValue(remaining, key),
+      ).length,
+      success: presentKeys.every(
+        (key) => !hasLocalStorageValue(remaining, key),
+      ),
+    };
   } catch (error) {
     logger.warn("Failed to remove legacy local storage keys: {error}", {
       error: formatErrorMessage(error),
     });
-    return false;
+    return {
+      removedArtifactCount: 0,
+      success: false,
+    };
   }
-
-  return legacyLocalStorageKeys.every((key) => !Object.hasOwn(remaining, key));
 }
 
-async function clearLegacyAlarms(): Promise<boolean> {
-  let alarms: unknown[];
+async function clearLegacyAlarms(): Promise<LegacyCleanupStepResult> {
+  let alarmsBefore: unknown[];
+  let alarmsAfter: unknown[];
   try {
-    await Promise.all(
-      legacyAlarmNames.map((alarmName) => clearAlarm(alarmName)),
-    );
-
-    alarms = await Promise.all(
+    alarmsBefore = await Promise.all(
       legacyAlarmNames.map((alarmName) => getAlarm(alarmName)),
     );
+
+    const presentAlarmNames = legacyAlarmNames.filter(
+      (alarmName, index) => alarmsBefore[index] !== undefined,
+    );
+
+    if (presentAlarmNames.length === 0) {
+      return {
+        removedArtifactCount: 0,
+        success: true,
+      };
+    }
+
+    await Promise.all(
+      presentAlarmNames.map((alarmName) => clearAlarm(alarmName)),
+    );
+
+    alarmsAfter = await Promise.all(
+      presentAlarmNames.map((alarmName) => getAlarm(alarmName)),
+    );
+
+    return {
+      removedArtifactCount: alarmsAfter.filter((alarm) => alarm === undefined)
+        .length,
+      success: alarmsAfter.every((alarm) => alarm === undefined),
+    };
   } catch (error) {
     logger.warn("Failed to clear legacy alarms: {error}", {
       error: formatErrorMessage(error),
     });
-    return false;
+    return {
+      removedArtifactCount: 0,
+      success: false,
+    };
   }
-
-  return alarms.every((alarm) => alarm === undefined);
 }
 
-async function deleteLegacyIndexedDb(): Promise<boolean> {
+async function hasLegacyIndexedDb(): Promise<boolean | undefined> {
+  if (typeof indexedDB === "undefined") {
+    return undefined;
+  }
+
+  if (!canListIndexedDbDatabases(indexedDB)) {
+    return undefined;
+  }
+
+  try {
+    const databases = await indexedDB.databases();
+    return databases.some((database) => database.name === legacyIndexedDbName);
+  } catch (error) {
+    logger.warn(
+      "Failed to list IndexedDB databases while checking for legacy DB {dbName}: {error}",
+      {
+        dbName: legacyIndexedDbName,
+        error: formatErrorMessage(error),
+      },
+    );
+    return undefined;
+  }
+}
+
+async function deleteLegacyIndexedDb(): Promise<LegacyCleanupStepResult> {
   if (typeof indexedDB === "undefined") {
     logger.warn("indexedDB is unavailable, skipping legacy DB cleanup");
-    return false;
+    return {
+      removedArtifactCount: 0,
+      success: false,
+    };
+  }
+
+  const hadLegacyDb = await hasLegacyIndexedDb();
+
+  if (hadLegacyDb === false) {
+    return {
+      removedArtifactCount: 0,
+      success: true,
+    };
   }
 
   // cspell:ignore IDBOpenDBRequest
@@ -434,7 +538,10 @@ async function deleteLegacyIndexedDb(): Promise<boolean> {
       dbName: legacyIndexedDbName,
       error: formatErrorMessage(error),
     });
-    return false;
+    return {
+      removedArtifactCount: 0,
+      success: false,
+    };
   }
 
   const { promise, resolve } = Promise.withResolvers<boolean>();
@@ -458,26 +565,45 @@ async function deleteLegacyIndexedDb(): Promise<boolean> {
     resolve(false);
   });
 
-  return await promise;
+  const success = await promise;
+
+  return {
+    removedArtifactCount: success && hadLegacyDb ? 1 : 0,
+    success,
+  };
 }
 
 export async function cleanupLegacyV1State(): Promise<void> {
-  const [localStorageRemoved, alarmsCleared, indexedDbDeleted] =
+  const [localStorageCleanup, alarmsCleanup, indexedDbCleanup] =
     await Promise.all([
       removeLegacyLocalStorageKeys(),
       clearLegacyAlarms(),
       deleteLegacyIndexedDb(),
     ]);
 
-  if (!localStorageRemoved || !alarmsCleared || !indexedDbDeleted) {
+  if (
+    !localStorageCleanup.success ||
+    !alarmsCleanup.success ||
+    !indexedDbCleanup.success
+  ) {
     logger.warn(
       "Legacy v1 cleanup remains incomplete (localStorageRemoved={localStorageRemoved}, alarmsCleared={alarmsCleared}, indexedDbDeleted={indexedDbDeleted})",
       {
-        localStorageRemoved,
-        alarmsCleared,
-        indexedDbDeleted,
+        localStorageRemoved: localStorageCleanup.success,
+        alarmsCleared: alarmsCleanup.success,
+        indexedDbDeleted: indexedDbCleanup.success,
       },
     );
+    return;
+  }
+
+  const removedArtifactCount =
+    localStorageCleanup.removedArtifactCount +
+    alarmsCleanup.removedArtifactCount +
+    indexedDbCleanup.removedArtifactCount;
+
+  if (removedArtifactCount === 0) {
+    logger.debug("Legacy v1 cleanup was not needed");
     return;
   }
 


### PR DESCRIPTION
Показываем информационный лог о завершении очистки v1 только тогда, когда действительно были удалены legacy-артефакты. Если очищать было нечего, теперь пишем debug-сообщение о том, что cleanup не требовался. Добавлены тесты на сценарии с реальной очисткой, no-op и неполной очисткой.