### PR TITLE
Persist root config cache across reloads

### DIFF
--- a/src/entrypoints/background/@services/root-config-service.test.ts
+++ b/src/entrypoints/background/@services/root-config-service.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type RootConfig,
+  rootConfigSchema,
+  rootConfigSeed,
+} from "@/shared/@model/root-config";
+import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
+
+import { AliasManager } from "../@service-helpers/alias-manager";
+
+const rootConfigStorageKey = "local:root-config-cache";
+
+const { fetchFromRemoteSystemMock, loggerMock, storageState } = vi.hoisted(
+  () => {
+    const values = new Map<string, unknown>();
+    const watchers = new Map<string, Set<(value: unknown) => void>>();
+
+    return {
+      fetchFromRemoteSystemMock: vi.fn(),
+      loggerMock: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+      storageState: { values, watchers },
+    };
+  },
+);
+
+vi.mock("@/shared/@logging/categories", () => ({
+  getBackgroundLogger: () => loggerMock,
+}));
+
+vi.mock("../@service-helpers/fetch-from-remote-system", () => ({
+  fetchFromRemoteSystem: fetchFromRemoteSystemMock,
+}));
+
+vi.mock("../@service-helpers/store-with-schema", () => ({
+  defineStoreWithSchema: (name: string) => ({
+    getValue: () => Promise.resolve(storageState.values.get(name)),
+    setValue: (value: unknown) => {
+      storageState.values.set(name, value);
+
+      for (const callback of storageState.watchers.get(name) ?? []) {
+        callback(value);
+      }
+
+      return Promise.resolve();
+    },
+    watch: (callback: (value: unknown) => void) => {
+      const callbacks = storageState.watchers.get(name) ?? new Set();
+      callbacks.add(callback);
+      storageState.watchers.set(name, callbacks);
+
+      return () => {
+        callbacks.delete(callback);
+        if (callbacks.size === 0) {
+          storageState.watchers.delete(name);
+        }
+      };
+    },
+  }),
+}));
+
+const { RootConfigService } = await import("./root-config-service");
+
+function createRootConfig({
+  extensionVersionRange = "*",
+  generatedAt = "2026-03-28T12:00:00Z",
+}: {
+  extensionVersionRange?: string;
+  generatedAt?: string;
+} = {}): RootConfig {
+  const rootConfigSeedClone = structuredClone(rootConfigSeed);
+
+  return rootConfigSchema.parse({
+    ...rootConfigSeedClone,
+    extensionVersionRange,
+    generatedAt,
+    remoteSystemLookup: {
+      ...rootConfigSeedClone.remoteSystemLookup,
+      staticApi: {
+        ...rootConfigSeedClone.remoteSystemLookup.staticApi,
+        listLookup: Object.fromEntries(
+          Object.entries(
+            rootConfigSeedClone.remoteSystemLookup.staticApi.listLookup,
+          ).map(([listId, listInfo]) => [
+            listId,
+            {
+              ...listInfo,
+              generatedAt,
+            },
+          ]),
+        ),
+      },
+    },
+  });
+}
+
+function createPersistedRootConfigState(
+  rootConfig: RootConfig,
+  fetchedAt: string,
+) {
+  return {
+    rootConfig,
+    fetchedAt: isoDateTimeSchema.parse(fetchedAt),
+  };
+}
+
+function createSuccessfulFetchResult(json: unknown) {
+  return {
+    success: true as const,
+    response: Response.json(json),
+  };
+}
+
+function createService() {
+  return new RootConfigService({
+    aliasManagerForStaticApi: new AliasManager(
+      "staticApi",
+      rootConfigSeed.remoteSystemLookup.staticApi.aliasLookup,
+    ),
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-03-28T12:00:00Z"));
+
+  fetchFromRemoteSystemMock.mockReset();
+  loggerMock.debug.mockReset();
+  loggerMock.error.mockReset();
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+
+  storageState.values.clear();
+  storageState.watchers.clear();
+});
+
+afterEach(async () => {
+  await vi.runOnlyPendingTimersAsync();
+  vi.useRealTimers();
+});
+
+describe("RootConfigService", () => {
+  it("hydrates a fresh cached root config and skips refetching", async () => {
+    const cachedRootConfig = createRootConfig({
+      extensionVersionRange: ">=2.0.0",
+      generatedAt: "2026-03-28T11:55:00Z",
+    });
+
+    storageState.values.set(
+      rootConfigStorageKey,
+      createPersistedRootConfigState(cachedRootConfig, "2026-03-28T11:58:00Z"),
+    );
+
+    const service = createService();
+
+    await expect(service.get()).resolves.toEqual(cachedRootConfig);
+    await expect(service.getExtensionVersionRange()).resolves.toBe(">=2.0.0");
+    expect(fetchFromRemoteSystemMock).not.toHaveBeenCalled();
+  });
+
+  it("fetches and persists the root config when no cache exists", async () => {
+    const fetchedRootConfig = createRootConfig({
+      extensionVersionRange: "<3.0.0",
+    });
+
+    fetchFromRemoteSystemMock.mockResolvedValue(
+      createSuccessfulFetchResult(fetchedRootConfig),
+    );
+
+    const service = createService();
+
+    await expect(service.get()).resolves.toEqual(fetchedRootConfig);
+    await expect(service.getExtensionVersionRange()).resolves.toBe("<3.0.0");
+
+    expect(fetchFromRemoteSystemMock).toHaveBeenCalledTimes(1);
+    expect(storageState.values.get(rootConfigStorageKey)).toEqual(
+      createPersistedRootConfigState(fetchedRootConfig, "2026-03-28T12:00:00Z"),
+    );
+  });
+
+  it("serves stale cached config while a refresh is still in flight", async () => {
+    const cachedRootConfig = createRootConfig({
+      extensionVersionRange: ">=1.0.0",
+      generatedAt: "2026-03-28T10:30:00Z",
+    });
+    const refreshedRootConfig = createRootConfig({
+      extensionVersionRange: ">=4.0.0",
+      generatedAt: "2026-03-28T12:00:00Z",
+    });
+
+    storageState.values.set(
+      rootConfigStorageKey,
+      createPersistedRootConfigState(cachedRootConfig, "2026-03-28T10:30:00Z"),
+    );
+
+    const deferredFetch =
+      Promise.withResolvers<ReturnType<typeof createSuccessfulFetchResult>>();
+
+    fetchFromRemoteSystemMock.mockReturnValue(deferredFetch.promise);
+
+    const service = createService();
+    const pollPromise = service.poll(undefined);
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(pollPromise).resolves.toMatchObject({
+      value: cachedRootConfig,
+    });
+    expect(fetchFromRemoteSystemMock).toHaveBeenCalledTimes(1);
+
+    deferredFetch.resolve(createSuccessfulFetchResult(refreshedRootConfig));
+    await Promise.resolve();
+
+    await expect(service.get()).resolves.toEqual(refreshedRootConfig);
+  });
+
+  it("keeps stale cached state after failed refreshes and retries again after reload", async () => {
+    const cachedRootConfig = createRootConfig({
+      extensionVersionRange: ">=1.0.0",
+      generatedAt: "2026-03-28T10:30:00Z",
+    });
+    const persistedState = createPersistedRootConfigState(
+      cachedRootConfig,
+      "2026-03-28T10:30:00Z",
+    );
+
+    storageState.values.set(rootConfigStorageKey, persistedState);
+
+    fetchFromRemoteSystemMock.mockResolvedValue({
+      success: false as const,
+      reason: "connectionFailed" as const,
+    });
+
+    const service = createService();
+    const firstPollPromise = service.poll(undefined);
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(firstPollPromise).resolves.toMatchObject({
+      value: cachedRootConfig,
+    });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(fetchFromRemoteSystemMock).toHaveBeenCalledTimes(3);
+    expect(storageState.values.get(rootConfigStorageKey)).toEqual(
+      persistedState,
+    );
+
+    const reloadedService = createService();
+    const secondPollPromise = reloadedService.poll(undefined);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchFromRemoteSystemMock).toHaveBeenCalledTimes(4);
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await expect(secondPollPromise).resolves.toMatchObject({
+      value: cachedRootConfig,
+    });
+
+    // Flush the remaining retry delays (10s × 2) from the still-running
+    // doUpdateIfNeeded loop so they don't leak into the next test.
+    await vi.advanceTimersByTimeAsync(20_000);
+  });
+
+  it("updates only extension version range for incompatible refreshes", async () => {
+    const cachedRootConfig = createRootConfig({
+      extensionVersionRange: ">=1.0.0",
+      generatedAt: "2026-03-28T10:30:00Z",
+    });
+    const persistedState = createPersistedRootConfigState(
+      cachedRootConfig,
+      "2026-03-28T10:30:00Z",
+    );
+
+    storageState.values.set(rootConfigStorageKey, persistedState);
+
+    fetchFromRemoteSystemMock.mockResolvedValue(
+      createSuccessfulFetchResult({
+        extensionVersionRange: "<5.0.0",
+      }),
+    );
+
+    const service = createService();
+
+    await expect(service.get()).resolves.toEqual(cachedRootConfig);
+    await expect(service.getExtensionVersionRange()).resolves.toBe("<5.0.0");
+
+    expect(storageState.values.get(rootConfigStorageKey)).toEqual(
+      persistedState,
+    );
+  });
+});

--- a/src/entrypoints/background/@services/root-config-service.ts
+++ b/src/entrypoints/background/@services/root-config-service.ts
@@ -1,4 +1,5 @@
 import { delay } from "es-toolkit";
+import { z } from "zod/mini";
 
 import { getBackgroundLogger } from "@/shared/@logging/categories";
 import {
@@ -13,9 +14,11 @@ import {
   type PollVersion,
 } from "@/shared/@pollable/core";
 import type { SemverRange } from "@/shared/@primitives/semver";
+import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
 
 import type { AliasManager } from "../@service-helpers/alias-manager";
 import { fetchFromRemoteSystem } from "../@service-helpers/fetch-from-remote-system";
+import { defineStoreWithSchema } from "../@service-helpers/store-with-schema";
 
 const logger = getBackgroundLogger(["root-config-service"]);
 
@@ -24,14 +27,27 @@ const minRefetchIntervalAfterSuccessInMs = 30 * 60 * 1000;
 const minRetryIntervalAfterFailureInMs = 10 * 1000;
 const maxRetryCount = 3;
 
+const persistedRootConfigStateSchema = z.readonly(
+  z.object({
+    rootConfig: rootConfigSchema,
+    fetchedAt: isoDateTimeSchema,
+  }),
+);
+
+const rootConfigStore = defineStoreWithSchema(
+  "local:root-config-cache",
+  persistedRootConfigStateSchema,
+);
+
 export class RootConfigService {
-  private aliasManagerForStaticApi: AliasManager;
+  private readonly aliasManagerForStaticApi: AliasManager;
 
-  private state: "idle" | "fetching";
-  private lastFetchAttempt: { success: boolean; fetchedAt: number } | undefined;
+  private lastSuccessfulFetchAt: number | undefined;
 
+  private readonly hydrateFromStorePromise: Promise<void>;
   private pollableRootConfig: Pollable<RootConfig>;
   private pollableExtensionVersionRange: Pollable<SemverRange>;
+  private updateIfNeededPromise: Promise<void> | undefined;
 
   constructor({
     aliasManagerForStaticApi,
@@ -43,7 +59,7 @@ export class RootConfigService {
     this.pollableExtensionVersionRange = new Pollable(
       rootConfigSeed.extensionVersionRange,
     );
-    this.state = "idle";
+    this.hydrateFromStorePromise = this.hydrateFromStore();
   }
 
   async get(): Promise<RootConfig> {
@@ -59,12 +75,6 @@ export class RootConfigService {
     return this.pollableRootConfig.poll(lastPollVersion);
   }
 
-  private async waitForIdle(): Promise<void> {
-    while (this.state !== "idle") {
-      await delay(100);
-    }
-  }
-
   async getExtensionVersionRange(): Promise<SemverRange> {
     const result = await this.pollExtensionVersionRange(undefined);
     return result.value;
@@ -73,33 +83,81 @@ export class RootConfigService {
   async pollExtensionVersionRange(
     lastPollVersion: PollVersion | undefined,
   ): Promise<PollResult<SemverRange>> {
+    await this.hydrateFromStorePromise;
     return this.pollableExtensionVersionRange.poll(lastPollVersion);
   }
 
   private async updateIfNeeded(): Promise<void> {
-    await this.waitForIdle();
+    await this.hydrateFromStorePromise;
 
+    this.updateIfNeededPromise ??= this.doUpdateIfNeeded().finally(() => {
+      this.updateIfNeededPromise = undefined;
+    });
+
+    await this.updateIfNeededPromise;
+  }
+
+  private applyPersistedRootConfigState(
+    persistedState: z.infer<typeof persistedRootConfigStateSchema>,
+  ): void {
+    this.pollableRootConfig.setValue(persistedState.rootConfig);
+    this.pollableExtensionVersionRange.setValue(
+      persistedState.rootConfig.extensionVersionRange,
+    );
+    this.lastSuccessfulFetchAt = new Date(persistedState.fetchedAt).getTime();
+  }
+
+  private async hydrateFromStore(): Promise<void> {
+    try {
+      const persistedState = await rootConfigStore.getValue();
+      if (!persistedState) {
+        return;
+      }
+
+      this.applyPersistedRootConfigState(persistedState);
+
+      logger.debug("Hydrated root config from store: {rootConfig}", {
+        rootConfig: persistedState.rootConfig,
+      });
+    } catch (error) {
+      logger.error("Failed to hydrate root config from store: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async persistRootConfig(rootConfig: RootConfig): Promise<void> {
+    const persistedState = {
+      rootConfig,
+      fetchedAt: isoDateTimeSchema.parse(Date.now()),
+    };
+
+    this.applyPersistedRootConfigState(persistedState);
+
+    try {
+      await rootConfigStore.setValue(persistedState);
+    } catch (error) {
+      logger.error("Failed to persist root config: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async doUpdateIfNeeded(): Promise<void> {
     const now = Date.now();
 
     if (
-      this.lastFetchAttempt &&
-      now - this.lastFetchAttempt.fetchedAt < minRefetchIntervalAfterSuccessInMs
+      this.lastSuccessfulFetchAt !== undefined &&
+      now - this.lastSuccessfulFetchAt < minRefetchIntervalAfterSuccessInMs
     ) {
       logger.debug(
         "Root config update is not needed (it was fetched {elapsedTime} seconds ago)",
         {
-          elapsedTime: Math.floor(
-            (now - this.lastFetchAttempt.fetchedAt) / 1000,
-          ),
+          elapsedTime: Math.floor((now - this.lastSuccessfulFetchAt) / 1000),
         },
       );
       return;
     }
-
-    // Prevent multiple parallel fetches on startup
-    this.lastFetchAttempt ??= { success: false, fetchedAt: now };
-
-    this.state = "fetching";
 
     for (let attempt = 0; attempt < maxRetryCount; attempt++) {
       if (attempt > 0) {
@@ -125,8 +183,6 @@ export class RootConfigService {
           continue;
         }
 
-        this.lastFetchAttempt = { success: false, fetchedAt: Date.now() };
-        this.state = "idle";
         return;
       }
 
@@ -158,8 +214,6 @@ export class RootConfigService {
             },
           );
 
-          this.lastFetchAttempt = { success: false, fetchedAt: Date.now() };
-          this.state = "idle";
           return;
         }
 
@@ -167,17 +221,10 @@ export class RootConfigService {
           continue;
         }
 
-        this.lastFetchAttempt = { success: false, fetchedAt: Date.now() };
-        this.state = "idle";
         return;
       }
 
-      this.pollableRootConfig.setValue(parseResult.data);
-      this.pollableExtensionVersionRange.setValue(
-        parseResult.data.extensionVersionRange,
-      );
-      this.lastFetchAttempt = { success: true, fetchedAt: Date.now() };
-      this.state = "idle";
+      await this.persistRootConfig(parseResult.data);
 
       logger.debug("Root config updated: {rootConfig}", {
         rootConfig: parseResult.data,


### PR DESCRIPTION
Добавлен постоянный кэш для root-config в локальном хранилище. После перезагрузки расширения используется последний успешно полученный конфиг и не запрашивается root-config.json заново в пределах интервала обновления. Также добавлены тесты на гидрацию кэша, первичное сохранение, поведение со старым кэшем, ошибки обновления и несовместимый ответ сервера.