### PR TITLE
Persist auth state cache across reloads

### DIFF
--- a/src/entrypoints/background/@service-helpers/store-with-schema.ts
+++ b/src/entrypoints/background/@service-helpers/store-with-schema.ts
@@ -20,6 +20,7 @@ function patchNameIfNeeded(name: StorageItemKey): StorageItemKey {
 export type StoreWithSchema<T extends z.ZodMiniType<JsonValue | undefined>> = {
   getValue: () => Promise<z.infer<T> | undefined>;
   setValue: (value: z.infer<T>) => Promise<void>;
+  clearValue: () => Promise<void>;
   watch: (callback: (value: z.infer<T>) => void) => () => void;
 };
 
@@ -101,6 +102,8 @@ export function defineStoreWithSchema<T extends z.ZodMiniType<JsonValue>>(
     },
 
     setValue: (value) => storageItem.setValue(value),
+
+    clearValue: () => storageItem.setValue(undefined),
 
     watch: (callback) =>
       storageItem.watch((value) => {

--- a/src/entrypoints/background/@services/auth-service.test.ts
+++ b/src/entrypoints/background/@services/auth-service.test.ts
@@ -1,0 +1,665 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { type AuthInput, authInputSchema } from "@/shared/@model/auth";
+import { rootConfigSeed } from "@/shared/@model/root-config";
+import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
+
+import { AliasManager } from "../@service-helpers/alias-manager";
+
+const authInputStorageKey = "sync:auth-input";
+const authStateStorageKey = "local:auth-state-cache";
+
+const { loggerMock, orpcState, storageState } = vi.hoisted(() => {
+  const values = new Map<string, unknown>();
+  const getValueImplementationByName = new Map<
+    string,
+    () => Promise<unknown>
+  >();
+  const watchers = new Map<string, Set<(value: unknown) => void>>();
+
+  class MockOrpcErrorRemoteSystemUnavailable extends Error {
+    reason: string;
+
+    constructor(message: string, reason: string) {
+      super(message);
+      this.reason = reason;
+    }
+  }
+
+  return {
+    loggerMock: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    orpcState: {
+      OrpcErrorRemoteSystemUnavailable: MockOrpcErrorRemoteSystemUnavailable,
+      getMe: vi.fn(),
+    },
+    storageState: { getValueImplementationByName, values, watchers },
+  };
+});
+
+vi.mock("@/shared/@logging/categories", () => ({
+  getBackgroundLogger: () => loggerMock,
+}));
+
+vi.mock("../@service-helpers/orpc", () => ({
+  orpcClient: {
+    getMe: orpcState.getMe,
+  },
+  OrpcErrorRemoteSystemUnavailable: orpcState.OrpcErrorRemoteSystemUnavailable,
+}));
+
+vi.mock("../@service-helpers/store-with-schema", () => ({
+  defineStoreWithSchema: (name: string) => ({
+    getValue: () =>
+      storageState.getValueImplementationByName.get(name)?.() ??
+      Promise.resolve(storageState.values.get(name)),
+    setValue: (value: unknown) => {
+      storageState.values.set(name, value);
+
+      for (const callback of storageState.watchers.get(name) ?? []) {
+        callback(value);
+      }
+
+      return Promise.resolve();
+    },
+    clearValue: () => {
+      storageState.values.delete(name);
+
+      for (const callback of storageState.watchers.get(name) ?? []) {
+        callback(undefined);
+      }
+
+      return Promise.resolve();
+    },
+    watch: (callback: (value: unknown) => void) => {
+      const callbacks = storageState.watchers.get(name) ?? new Set();
+      callbacks.add(callback);
+      storageState.watchers.set(name, callbacks);
+
+      return () => {
+        callbacks.delete(callback);
+        if (callbacks.size === 0) {
+          storageState.watchers.delete(name);
+        }
+      };
+    },
+  }),
+}));
+
+const { AuthService } = await import("./auth-service");
+
+function createDeferred<T>() {
+  let resolvePromise!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+}
+
+function createAuthInput({
+  accessCode = "demo-code",
+  accessCodeEnteredAt = "2026-03-28T12:00:00Z",
+}: {
+  accessCode?: string;
+  accessCodeEnteredAt?: string;
+} = {}): AuthInput {
+  return authInputSchema.parse({
+    accessCode,
+    accessCodeEnteredAt,
+  });
+}
+
+function createValidAuthStatus({
+  accessLevel = 2,
+  expiresAt,
+  permissionLookup = { inspectAccount: true },
+  pointCount = 123,
+}: {
+  accessLevel?: number;
+  expiresAt?: string;
+  permissionLookup?: Record<string, true>;
+  pointCount?: number;
+} = {}) {
+  return {
+    state: "valid" as const,
+    accessLevel,
+    ...(expiresAt ? { expiresAt: isoDateTimeSchema.parse(expiresAt) } : {}),
+    permissionLookup,
+    pointCount,
+  };
+}
+
+function createInvalidAuthStatus(
+  authInput: AuthInput,
+  {
+    accessCodeRecognized = false,
+    errorMessage = "Invalid access code",
+  }: {
+    accessCodeRecognized?: boolean;
+    errorMessage?: string;
+  } = {},
+) {
+  return {
+    state: "invalid" as const,
+    accessCode: authInput.accessCode,
+    accessCodeEnteredAt: authInput.accessCodeEnteredAt,
+    accessCodeRecognized,
+    errorMessage,
+  };
+}
+
+function createPersistedAuthState({
+  authInput,
+  authStatus,
+  checkedAt,
+}: {
+  authInput: AuthInput;
+  authStatus:
+    | ReturnType<typeof createValidAuthStatus>
+    | ReturnType<typeof createInvalidAuthStatus>;
+  checkedAt: string;
+}) {
+  return {
+    authInput,
+    authStatus,
+    checkedAt: isoDateTimeSchema.parse(checkedAt),
+  };
+}
+
+function queueGetMeSuccess(
+  body: ReturnType<typeof createValidAuthStatus> | Record<string, unknown>,
+) {
+  orpcState.getMe.mockResolvedValueOnce([undefined, { body }]);
+}
+
+function queueDeferredGetMeSuccess(
+  body: ReturnType<typeof createValidAuthStatus> | Record<string, unknown>,
+) {
+  const deferred = createDeferred<
+    [
+      undefined,
+      {
+        body:
+          | ReturnType<typeof createValidAuthStatus>
+          | Record<string, unknown>;
+      },
+    ]
+  >();
+
+  orpcState.getMe.mockReturnValueOnce(deferred.promise);
+
+  return {
+    resolve: () => {
+      deferred.resolve([undefined, { body }]);
+    },
+  };
+}
+
+function queueGetMeUnknown() {
+  orpcState.getMe.mockResolvedValueOnce([
+    new orpcState.OrpcErrorRemoteSystemUnavailable(
+      "Unavailable",
+      "connectionFailed",
+    ),
+    undefined,
+  ]);
+}
+
+const createdServices: Array<InstanceType<typeof AuthService>> = [];
+
+function createService() {
+  const service = new AuthService({
+    aliasManagerForDynamicApi: new AliasManager(
+      "dynamicApi",
+      rootConfigSeed.remoteSystemLookup.dynamicApi.aliasLookup,
+    ),
+  });
+
+  createdServices.push(service);
+  return service;
+}
+
+async function settleInitialization(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-03-28T12:00:00Z"));
+
+  loggerMock.debug.mockReset();
+  loggerMock.error.mockReset();
+  loggerMock.info.mockReset();
+  loggerMock.warn.mockReset();
+  orpcState.getMe.mockReset();
+  storageState.values.clear();
+  storageState.getValueImplementationByName.clear();
+  storageState.watchers.clear();
+  createdServices.length = 0;
+});
+
+afterEach(async () => {
+  for (const service of createdServices) {
+    service[Symbol.dispose]();
+  }
+
+  await vi.runOnlyPendingTimersAsync();
+  vi.useRealTimers();
+});
+
+describe("AuthService", () => {
+  it("hydrates a fresh cached valid auth state and skips automatic get-me", async () => {
+    const authInput = createAuthInput();
+    const authStatus = createValidAuthStatus({
+      expiresAt: "2026-03-28T12:30:00Z",
+    });
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput,
+        authStatus,
+        checkedAt: "2026-03-28T11:58:00Z",
+      }),
+    );
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(service.getAuthStatus()).toEqual(authStatus);
+    expect(orpcState.getMe).not.toHaveBeenCalled();
+  });
+
+  it("hydrates a fresh cached invalid auth state and skips automatic get-me", async () => {
+    const authInput = createAuthInput();
+    const authStatus = createInvalidAuthStatus(authInput, {
+      accessCodeRecognized: true,
+    });
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput,
+        authStatus,
+        checkedAt: "2026-03-28T11:58:00Z",
+      }),
+    );
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(service.getAuthStatus()).toEqual(authStatus);
+    expect(orpcState.getMe).not.toHaveBeenCalled();
+  });
+
+  it("ignores cached auth state when access code text differs", async () => {
+    const currentAuthInput = createAuthInput({ accessCode: "new-code" });
+    const cachedAuthInput = createAuthInput({ accessCode: "old-code" });
+    const fetchedAuthStatus = createValidAuthStatus();
+
+    storageState.values.set(authInputStorageKey, currentAuthInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput: cachedAuthInput,
+        authStatus: createValidAuthStatus(),
+        checkedAt: "2026-03-28T11:58:00Z",
+      }),
+    );
+    queueGetMeSuccess(fetchedAuthStatus);
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(orpcState.getMe).toHaveBeenCalledTimes(1);
+    expect(service.getAuthStatus()).toEqual(fetchedAuthStatus);
+  });
+
+  it("ignores cached auth state when accessCodeEnteredAt differs", async () => {
+    const currentAuthInput = createAuthInput({
+      accessCodeEnteredAt: "2026-03-28T12:00:00Z",
+    });
+    const cachedAuthInput = createAuthInput({
+      accessCodeEnteredAt: "2026-03-28T11:59:00Z",
+    });
+    const fetchedAuthStatus = createValidAuthStatus();
+
+    storageState.values.set(authInputStorageKey, currentAuthInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput: cachedAuthInput,
+        authStatus: createValidAuthStatus(),
+        checkedAt: "2026-03-28T11:58:00Z",
+      }),
+    );
+    queueGetMeSuccess(fetchedAuthStatus);
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(orpcState.getMe).toHaveBeenCalledTimes(1);
+    expect(service.getAuthStatus()).toEqual(fetchedAuthStatus);
+  });
+
+  it("ignores cached valid auth state when expiresAt has passed", async () => {
+    const authInput = createAuthInput();
+    const fetchedAuthStatus = createValidAuthStatus({
+      expiresAt: "2026-03-28T13:00:00Z",
+    });
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput,
+        authStatus: createValidAuthStatus({
+          expiresAt: "2026-03-28T11:59:00Z",
+        }),
+        checkedAt: "2026-03-28T11:58:00Z",
+      }),
+    );
+    queueGetMeSuccess(fetchedAuthStatus);
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(orpcState.getMe).toHaveBeenCalledTimes(1);
+    expect(service.getAuthStatus()).toEqual(fetchedAuthStatus);
+  });
+
+  it("rechecks automatically when the cached auth state is stale", async () => {
+    const authInput = createAuthInput();
+    const fetchedAuthStatus = createValidAuthStatus();
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput,
+        authStatus: createValidAuthStatus(),
+        checkedAt: "2026-03-28T11:54:59Z",
+      }),
+    );
+    queueGetMeSuccess(fetchedAuthStatus);
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(orpcState.getMe).toHaveBeenCalledTimes(1);
+    expect(service.getAuthStatus()).toEqual(fetchedAuthStatus);
+  });
+
+  it("always bypasses the cache for manual refresh", async () => {
+    const authInput = createAuthInput();
+    const cachedAuthStatus = createValidAuthStatus({
+      pointCount: 1,
+      expiresAt: "2026-03-28T13:00:00Z",
+    });
+    const refreshedAuthStatus = createValidAuthStatus({
+      pointCount: 2,
+      expiresAt: "2026-03-28T13:00:00Z",
+    });
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput,
+        authStatus: cachedAuthStatus,
+        checkedAt: "2026-03-28T11:58:00Z",
+      }),
+    );
+
+    const service = createService();
+    await settleInitialization();
+    expect(orpcState.getMe).not.toHaveBeenCalled();
+
+    queueGetMeSuccess(refreshedAuthStatus);
+
+    const checkPromise = service.checkAuth();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(orpcState.getMe).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await checkPromise;
+
+    expect(service.getAuthStatus()).toEqual(refreshedAuthStatus);
+  });
+
+  it("does not persist unknown auth state", async () => {
+    const authInput = createAuthInput();
+
+    storageState.values.set(authInputStorageKey, authInput);
+    queueGetMeUnknown();
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(service.getAuthStatus()).toEqual({
+      state: "unknown",
+      ...authInput,
+    });
+    expect(storageState.values.has(authStateStorageKey)).toBe(false);
+  });
+
+  it("does not persist empty auth state", async () => {
+    storageState.values.set(
+      authInputStorageKey,
+      createAuthInput({ accessCode: "" }),
+    );
+
+    const service = createService();
+    await settleInitialization();
+
+    expect(service.getAuthStatus()).toEqual({
+      state: "empty",
+      accessCode: "",
+      accessCodeEnteredAt: "2026-03-28T12:00:00Z",
+    });
+    expect(storageState.values.has(authStateStorageKey)).toBe(false);
+  });
+
+  it("keeps the last persisted auth state when refresh returns unknown", async () => {
+    const authInput = createAuthInput();
+    const persistedAuthState = createPersistedAuthState({
+      authInput,
+      authStatus: createValidAuthStatus({
+        expiresAt: "2026-03-28T13:00:00Z",
+        pointCount: 10,
+      }),
+      checkedAt: "2026-03-28T11:58:00Z",
+    });
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.values.set(authStateStorageKey, persistedAuthState);
+
+    const service = createService();
+    await settleInitialization();
+
+    queueGetMeUnknown();
+    const checkPromise = service.checkAuth();
+    await vi.advanceTimersByTimeAsync(500);
+    await checkPromise;
+
+    expect(service.getAuthStatus()).toEqual({
+      state: "unknown",
+      ...authInput,
+    });
+    expect(storageState.values.get(authStateStorageKey)).toEqual(
+      persistedAuthState,
+    );
+  });
+
+  it("does not recheck twice when access code changes before initialization completes", async () => {
+    const authInput = createAuthInput();
+    const authStateLoadDeferred = createDeferred<unknown>();
+    const fetchedAuthStatus = createValidAuthStatus({
+      expiresAt: "2026-03-28T13:00:00Z",
+      pointCount: 999,
+    });
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.getValueImplementationByName.set(
+      authStateStorageKey,
+      () => authStateLoadDeferred.promise,
+    );
+
+    const service = createService();
+    await vi.advanceTimersByTimeAsync(0);
+
+    service.setAccessCode(authInput.accessCode);
+    queueGetMeSuccess(fetchedAuthStatus);
+
+    authStateLoadDeferred.resolve(undefined);
+    storageState.getValueImplementationByName.delete(authStateStorageKey);
+
+    await settleInitialization();
+    await settleInitialization();
+
+    expect(orpcState.getMe).toHaveBeenCalledTimes(1);
+    expect(service.getAuthStatus()).toEqual(fetchedAuthStatus);
+  });
+
+  it("rechecks changed auth input without waiting for the visible-duration delay", async () => {
+    const initialAuthInput = createAuthInput();
+    const refreshedAuthStatus = createValidAuthStatus({
+      expiresAt: "2026-03-28T13:00:00Z",
+      pointCount: 111,
+    });
+    const oldRequest = queueDeferredGetMeSuccess(
+      createValidAuthStatus({
+        expiresAt: "2026-03-28T13:00:00Z",
+        pointCount: 10,
+      }),
+    );
+
+    storageState.values.set(authInputStorageKey, initialAuthInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput: initialAuthInput,
+        authStatus: createValidAuthStatus({
+          expiresAt: "2026-03-28T13:00:00Z",
+          pointCount: 10,
+        }),
+        checkedAt: "2026-03-28T11:54:59Z",
+      }),
+    );
+
+    const service = createService();
+    await vi.advanceTimersByTimeAsync(0);
+
+    service.setAccessCode("new-code");
+    queueGetMeSuccess(refreshedAuthStatus);
+
+    oldRequest.resolve();
+    await settleInitialization();
+
+    expect(orpcState.getMe).toHaveBeenCalledTimes(2);
+
+    await settleInitialization();
+
+    expect(service.getAuthStatus()).toEqual(refreshedAuthStatus);
+  });
+
+  it("clears the persisted auth cache when access code changes", async () => {
+    const initialAuthInput = createAuthInput();
+    const newCheckedAt = "2026-03-28T12:00:00Z";
+
+    storageState.values.set(authInputStorageKey, initialAuthInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput: initialAuthInput,
+        authStatus: createValidAuthStatus({
+          expiresAt: "2026-03-28T13:00:00Z",
+        }),
+        checkedAt: "2026-03-28T11:58:00Z",
+      }),
+    );
+
+    const service = createService();
+    await settleInitialization();
+
+    queueGetMeSuccess(createValidAuthStatus({ pointCount: 999 }));
+
+    service.setAccessCode("new-code");
+    await settleInitialization();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(orpcState.getMe).toHaveBeenCalledTimes(1);
+    expect(storageState.values.get(authInputStorageKey)).toEqual(
+      createAuthInput({
+        accessCode: "new-code",
+        accessCodeEnteredAt: newCheckedAt,
+      }),
+    );
+
+    expect(storageState.values.get(authStateStorageKey)).toEqual(
+      createPersistedAuthState({
+        authInput: createAuthInput({
+          accessCode: "new-code",
+          accessCodeEnteredAt: newCheckedAt,
+        }),
+        authStatus: createValidAuthStatus({ pointCount: 999 }),
+        checkedAt: newCheckedAt,
+      }),
+    );
+  });
+
+  it("persists valid auth patches without refreshing checkedAt", async () => {
+    const authInput = createAuthInput();
+    const checkedAt = "2026-03-28T11:58:00Z";
+
+    storageState.values.set(authInputStorageKey, authInput);
+    storageState.values.set(
+      authStateStorageKey,
+      createPersistedAuthState({
+        authInput,
+        authStatus: createValidAuthStatus({
+          pointCount: 10,
+          expiresAt: "2026-03-28T13:00:00Z",
+          permissionLookup: { inspectAccount: true },
+        }),
+        checkedAt,
+      }),
+    );
+
+    const service = createService();
+    await settleInitialization();
+
+    service.patchPointCount(20);
+    service.patchPermissionLookup({
+      inspectAccount: true,
+      reportAccount: true,
+    });
+    await settleInitialization();
+
+    expect(storageState.values.get(authStateStorageKey)).toEqual(
+      createPersistedAuthState({
+        authInput,
+        authStatus: createValidAuthStatus({
+          pointCount: 20,
+          expiresAt: "2026-03-28T13:00:00Z",
+          permissionLookup: {
+            inspectAccount: true,
+            reportAccount: true,
+          },
+        }),
+        checkedAt,
+      }),
+    );
+  });
+});

--- a/src/entrypoints/background/@services/auth-service.ts
+++ b/src/entrypoints/background/@services/auth-service.ts
@@ -1,4 +1,5 @@
 import { delay } from "es-toolkit";
+import { z } from "zod/mini";
 
 import { getBackgroundLogger } from "@/shared/@logging/categories";
 import {
@@ -7,6 +8,7 @@ import {
   authInputSchema,
   type AuthStatus,
   type PermissionLookup,
+  permissionLookupSchema,
 } from "@/shared/@model/auth";
 import {
   Pollable,
@@ -41,10 +43,60 @@ const authInputStore = defineStoreWithSchema(
   { migrateDataFromV1: migrateAuthInputFromV1 },
 );
 
+const minRefetchIntervalAfterAuthCheckInMs = 5 * 60 * 1000;
+
 const defaultAuthInput: AuthInput = {
   accessCode: "",
   accessCodeEnteredAt: isoDateTimeSchema.parse(new Date(0)),
 };
+
+const persistedValidAuthStatusSchema = z.readonly(
+  z.object({
+    state: z.literal("valid"),
+    accessLevel: z.number(),
+    expiresAt: z.exactOptional(isoDateTimeSchema),
+    pointCount: z.number(),
+    permissionLookup: permissionLookupSchema,
+  }),
+);
+
+const persistedInvalidAuthStatusSchema = z.readonly(
+  z.object({
+    state: z.literal("invalid"),
+    accessCode: z.string(),
+    accessCodeEnteredAt: isoDateTimeSchema,
+    accessCodeRecognized: z.boolean(),
+    errorMessage: z.string(),
+  }),
+);
+
+const persistedAuthStatusSchema = z.union([
+  persistedInvalidAuthStatusSchema,
+  persistedValidAuthStatusSchema,
+]);
+
+const persistedAuthStateSchema = z.readonly(
+  z.object({
+    authInput: authInputSchema,
+    authStatus: persistedAuthStatusSchema,
+    checkedAt: isoDateTimeSchema,
+  }),
+);
+
+type PersistedAuthStatus = z.infer<typeof persistedAuthStatusSchema>;
+type PersistedAuthState = z.infer<typeof persistedAuthStateSchema>;
+
+const authStateStore = defineStoreWithSchema(
+  "local:auth-state-cache",
+  persistedAuthStateSchema,
+);
+
+function isSameAuthInput(left: AuthInput, right: AuthInput): boolean {
+  return (
+    left.accessCode === right.accessCode &&
+    left.accessCodeEnteredAt === right.accessCodeEnteredAt
+  );
+}
 
 function isProblemOutcome(
   value: unknown,
@@ -66,13 +118,16 @@ function hasBody(value: unknown): value is { body: unknown } {
 }
 
 export class AuthService {
-  private aliasManagerForDynamicApi: AliasManager;
+  private readonly aliasManagerForDynamicApi: AliasManager;
   private disposed = false;
+  private initialized = false;
 
   private pollableAuthInput: Pollable<AuthInput | undefined>;
   private pollableAuthStatus: Pollable<AuthStatus>;
   private pollableAuthCheck: Pollable<AuthCheck>;
+  private persistedAuthState: PersistedAuthState | undefined;
 
+  private readonly initializePromise: Promise<void>;
   private readonly storeWriteThrottleInMs = 1000;
 
   constructor({
@@ -86,8 +141,8 @@ export class AuthService {
     this.pollableAuthStatus = new Pollable<AuthStatus>({ state: "unknown" });
     this.pollableAuthCheck = new Pollable<AuthCheck>({ state: "idle" });
 
-    void this.checkAuth();
     void this.startSyncingAuthInputWithStore();
+    this.initializePromise = this.initialize();
   }
 
   [Symbol.dispose](): void {
@@ -126,6 +181,28 @@ export class AuthService {
     return result.value;
   }
 
+  private async initialize(): Promise<void> {
+    await this.waitUntilAuthInputReady();
+
+    const authInput = await this.getAuthInput();
+    await this.hydratePersistedAuthState(authInput);
+
+    if (this.shouldReusePersistedAuthState(authInput)) {
+      const persistedAuthState = this.persistedAuthState;
+      if (persistedAuthState) {
+        this.pollableAuthStatus.setValue(persistedAuthState.authStatus);
+        logger.debug("Hydrated auth state from cache: {authStatus}", {
+          authStatus: persistedAuthState.authStatus,
+        });
+      }
+      this.initialized = true;
+      return;
+    }
+
+    await this.checkAuthAfterInitialization({ force: false });
+    this.initialized = true;
+  }
+
   // TODO: Remove this method after the v1 -> v2 upgrade window closes.
   async waitUntilAuthInputReady(): Promise<void> {
     await this.pollAuthInput(undefined);
@@ -152,7 +229,130 @@ export class AuthService {
   }
 
   async checkAuth(): Promise<void> {
+    await this.initializePromise;
+    await this.checkAuthAfterInitialization({ force: true });
+  }
+
+  private shouldReusePersistedAuthState(authInput: AuthInput): boolean {
+    if (!this.persistedAuthState) {
+      return false;
+    }
+
+    if (!isSameAuthInput(this.persistedAuthState.authInput, authInput)) {
+      return false;
+    }
+
+    const now = Date.now();
+
+    if (
+      now - new Date(this.persistedAuthState.checkedAt).getTime() >=
+      minRefetchIntervalAfterAuthCheckInMs
+    ) {
+      return false;
+    }
+
+    if (
+      this.persistedAuthState.authStatus.state === "valid" &&
+      this.persistedAuthState.authStatus.expiresAt &&
+      new Date(this.persistedAuthState.authStatus.expiresAt).getTime() <= now
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private async hydratePersistedAuthState(authInput: AuthInput): Promise<void> {
+    try {
+      this.persistedAuthState = await authStateStore.getValue();
+    } catch (error) {
+      logger.error("Failed to hydrate auth state cache: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.persistedAuthState = undefined;
+      return;
+    }
+
+    if (!this.shouldReusePersistedAuthState(authInput)) {
+      return;
+    }
+  }
+
+  private async persistAuthState(state: PersistedAuthState): Promise<void> {
+    this.persistedAuthState = state;
+
+    try {
+      await authStateStore.setValue(state);
+    } catch (error) {
+      logger.error("Failed to persist auth state cache: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async clearPersistedAuthState(): Promise<void> {
+    this.persistedAuthState = undefined;
+
+    try {
+      await authStateStore.clearValue();
+    } catch (error) {
+      logger.error("Failed to clear auth state cache: {error}", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async persistAuthStatusAfterCheck(
+    authInput: AuthInput,
+    authStatus: PersistedAuthStatus,
+  ): Promise<void> {
+    await this.persistAuthState({
+      authInput,
+      authStatus,
+      checkedAt: isoDateTimeSchema.parse(Date.now()),
+    });
+  }
+
+  private async applyAuthStatusAfterCheck(
+    authInput: AuthInput,
+    authStatus: AuthStatus,
+  ): Promise<void> {
+    this.pollableAuthStatus.setValue(authStatus);
+
+    if (authStatus.state === "empty" || authStatus.state === "unknown") {
+      if (authStatus.state === "empty") {
+        await this.clearPersistedAuthState();
+      }
+      return;
+    }
+
+    await this.persistAuthStatusAfterCheck(authInput, authStatus);
+  }
+
+  private async checkAuthAfterInitialization({
+    force,
+  }: {
+    force: boolean;
+  }): Promise<void> {
     if (this.getAuthCheck().state === "ongoing") {
+      return;
+    }
+
+    const authInput = await this.getAuthInput();
+
+    if (!force && this.shouldReusePersistedAuthState(authInput)) {
+      const persistedAuthState = this.persistedAuthState;
+      if (persistedAuthState) {
+        this.pollableAuthStatus.setValue(persistedAuthState.authStatus);
+      }
+      return;
+    }
+
+    if (authInput.accessCode.length === 0) {
+      await this.applyAuthStatusAfterCheck(authInput, {
+        state: "empty",
+        ...authInput,
+      });
       return;
     }
 
@@ -161,57 +361,95 @@ export class AuthService {
       startedAt: isoDateTimeSchema.parse(new Date()),
     });
 
-    const authInput = await this.getAuthInput();
+    const checkStartedAt = Date.now();
+    const shouldEnsureCheckDurationIsVisible =
+      this.getAuthStatus().state === "valid";
+
+    const outcome = await this.fetchFromDynamicApiWithAccessCode("getMe");
+
+    let currentAuthInput = await this.getAuthInput();
+
+    if (!isSameAuthInput(currentAuthInput, authInput)) {
+      logger.info(
+        "Discarding auth check result because auth input changed during the request",
+      );
+
+      this.pollableAuthCheck.setValue({ state: "idle" });
+      void this.checkAuth();
+      return;
+    }
+
+    const remainingVisibleDurationInMs = checkStartedAt + 500 - Date.now();
+
+    if (
+      shouldEnsureCheckDurationIsVisible &&
+      remainingVisibleDurationInMs > 0
+    ) {
+      await delay(remainingVisibleDurationInMs);
+      currentAuthInput = await this.getAuthInput();
+    }
 
     let newAuthStatus: AuthStatus;
 
-    if (authInput.accessCode.length === 0) {
+    if (!outcome.problem) {
+      newAuthStatus = omitUndefined({
+        state: "valid" as const,
+        accessLevel: outcome.accessLevel,
+        expiresAt: outcome.expiresAt,
+        pointCount: outcome.pointCount,
+        permissionLookup: outcome.permissionLookup,
+      });
+    } else if (outcome.type === "bn:ext:invalid-access-code") {
       newAuthStatus = {
-        state: "empty",
-        ...authInput,
+        state: "invalid",
+        accessCode: authInput.accessCode,
+        accessCodeEnteredAt: authInput.accessCodeEnteredAt,
+        accessCodeRecognized: outcome.accessCodeRecognized ?? false,
+        errorMessage: outcome.description,
       };
     } else {
-      const [outcome] = await Promise.all([
-        this.fetchFromDynamicApiWithAccessCode("getMe"),
-        this.getAuthStatus().state === "valid" ? delay(500) : undefined, // Ensure check duration is visible to the user (if it's too fast, it's hard to notice that something is happening)
-      ]);
-
-      if (!outcome.problem) {
-        newAuthStatus = omitUndefined({
-          state: "valid" as const,
-          accessLevel: outcome.accessLevel,
-          expiresAt: outcome.expiresAt,
-          pointCount: outcome.pointCount,
-          permissionLookup: outcome.permissionLookup,
-        });
-      } else if (outcome.type === "bn:ext:invalid-access-code") {
-        newAuthStatus = {
-          state: "invalid",
-          accessCode: authInput.accessCode,
-          accessCodeEnteredAt: authInput.accessCodeEnteredAt,
-          accessCodeRecognized: outcome.accessCodeRecognized ?? false,
-          errorMessage: outcome.description,
-        };
-      } else {
-        newAuthStatus = {
-          state: "unknown",
-          ...authInput,
-        };
-      }
+      newAuthStatus = {
+        state: "unknown",
+        ...authInput,
+      };
     }
 
-    this.pollableAuthStatus.setValue(newAuthStatus);
+    if (!isSameAuthInput(currentAuthInput, authInput)) {
+      logger.info(
+        "Discarding auth check result because auth input changed during the request",
+      );
+
+      this.pollableAuthCheck.setValue({ state: "idle" });
+      void this.checkAuth();
+      return;
+    }
+
     this.pollableAuthCheck.setValue({ state: "idle" });
+    await this.applyAuthStatusAfterCheck(authInput, newAuthStatus);
   }
 
   setAccessCode(accessCode: string): void {
+    void this.setAccessCodeAndRecheck(accessCode);
+  }
+
+  private async setAccessCodeAndRecheck(accessCode: string): Promise<void> {
+    const wasInitialized = this.initialized;
+
     this.pollableAuthInput.setValue({
       accessCode: accessCode
         .slice(0, 1000) // mitigate accidental pastes of large strings
         .trim(),
       accessCodeEnteredAt: isoDateTimeSchema.parse(new Date()),
     });
-    void this.checkAuth();
+
+    await this.clearPersistedAuthState();
+
+    if (!wasInitialized) {
+      return;
+    }
+
+    await this.initializePromise;
+    await this.checkAuthAfterInitialization({ force: true });
   }
 
   public async fetchFromDynamicApiWithAccessCode<
@@ -300,7 +538,10 @@ export class AuthService {
       return;
     }
 
-    this.pollableAuthStatus.setValue({ ...authStatus, permissionLookup });
+    const newAuthStatus = { ...authStatus, permissionLookup };
+
+    this.pollableAuthStatus.setValue(newAuthStatus);
+    void this.persistPatchedValidAuthStatus(newAuthStatus);
 
     logger.debug("Patched permission lookup to {permissionLookup}", {
       permissionLookup,
@@ -317,8 +558,30 @@ export class AuthService {
       return;
     }
 
-    this.pollableAuthStatus.setValue({ ...authStatus, pointCount });
+    const newAuthStatus = { ...authStatus, pointCount };
+
+    this.pollableAuthStatus.setValue(newAuthStatus);
+    void this.persistPatchedValidAuthStatus(newAuthStatus);
 
     logger.debug("Patched point count to {pointCount}", { pointCount });
+  }
+
+  private async persistPatchedValidAuthStatus(
+    authStatus: PersistedAuthStatus & { state: "valid" },
+  ): Promise<void> {
+    const authInput = await this.getAuthInput();
+    const persistedAuthState = this.persistedAuthState;
+
+    if (
+      persistedAuthState?.authStatus.state !== "valid" ||
+      !isSameAuthInput(persistedAuthState.authInput, authInput)
+    ) {
+      return;
+    }
+
+    await this.persistAuthState({
+      ...persistedAuthState,
+      authStatus,
+    });
   }
 }

--- a/src/entrypoints/background/@services/root-config-service.test.ts
+++ b/src/entrypoints/background/@services/root-config-service.test.ts
@@ -49,6 +49,15 @@ vi.mock("../@service-helpers/store-with-schema", () => ({
 
       return Promise.resolve();
     },
+    clearValue: () => {
+      storageState.values.delete(name);
+
+      for (const callback of storageState.watchers.get(name) ?? []) {
+        callback(undefined);
+      }
+
+      return Promise.resolve();
+    },
     watch: (callback: (value: unknown) => void) => {
       const callbacks = storageState.watchers.get(name) ?? new Set();
       callbacks.add(callback);


### PR DESCRIPTION
Добавлен постоянный локальный кэш состояния авторизации. Теперь после перезагрузки расширения не делается лишний запрос к /get-me, если недавнее состояние ещё свежее и относится к тому же коду доступа.

Кэш привязан к полной идентичности auth input (код доступа и время его ввода), ограничен коротким TTL и дополнительно обрезается по expiresAt для валидного состояния. Ручное обновление всегда обходит кэш и делает реальный запрос. Состояния unknown и empty не сохраняются между перезагрузками. При смене кода доступа кэш очищается, а локальные патчи pointCount и permissionLookup сохраняются без продления времени последнего реального /get-me.