### PR TITLE
Handle quota-blocked static list updates

### DIFF
--- a/src/entrypoints/background/@services/static-lists-service.ts
+++ b/src/entrypoints/background/@services/static-lists-service.ts
@@ -8,6 +8,8 @@ import type {
   StaticListCombiningMode,
   StaticListItemOrigin,
   StaticListRemoteInstance,
+  StaticListRemoteUpdateIssue,
+  StaticListRemoteUpdateIssueStage,
   StaticListUpstreamInfo,
 } from "@/shared/@model/static-list-helpers";
 import type { StaticListMetadata } from "@/shared/@model/static-list-metadata";
@@ -16,6 +18,7 @@ import {
   type StaticListId,
   staticListIds,
   type StaticListItem,
+  type StaticListsDataIssueState,
   type StaticListSummary,
 } from "@/shared/@model/static-lists";
 import {
@@ -31,6 +34,7 @@ import {
 import type { AliasManager } from "../@service-helpers/alias-manager";
 import { fetchFromRemoteSystem } from "../@service-helpers/fetch-from-remote-system";
 import type { RootConfigService } from "./root-config-service";
+import { deriveStaticListsDataIssueState } from "./static-lists-service/data-issue-state";
 import {
   getStaticListDefinitionInfo,
   type StaticListDefinitionInfo,
@@ -61,6 +65,7 @@ import {
   shouldVerifyResumedLine,
   type StaticListRemoteRowsState,
 } from "./static-lists-service/remote-metadata-helpers";
+import { isQuotaExceededRemoteUpdateError } from "./static-lists-service/remote-update-issue-helpers";
 import {
   createStoredRemoteRow,
   prepareUnvalidatedLocalRow,
@@ -117,6 +122,12 @@ type RemoteStagingSession = {
   startedAtIso: IsoDateTime;
   targetInstance: StaticListRemoteInstance;
   targetTable: Table<StoredRemoteRow, number>;
+};
+
+type PopulateRemoteListOptions = {
+  allowBlockedRetry?: boolean;
+  deleteActiveCache?: boolean;
+  forcePopulate?: boolean;
 };
 
 async function* streamLines(
@@ -179,6 +190,18 @@ function omitRemoteActive<ListId extends StaticListId>(
   void remoteActiveOmitted;
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- removing an exact-optional property via rest is correct at runtime but TS loses that shape
   return metadataWithoutRemoteActive as StaticListMetadata<ListId>;
+}
+
+function omitRemoteUpdateIssue<ListId extends StaticListId>(
+  metadata: StaticListMetadata<ListId>,
+): StaticListMetadata<ListId> {
+  const {
+    remoteUpdateIssue: remoteUpdateIssueOmitted,
+    ...metadataWithoutRemoteUpdateIssue
+  } = metadata;
+  void remoteUpdateIssueOmitted;
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- removing an exact-optional property via rest is correct at runtime but TS loses that shape
+  return metadataWithoutRemoteUpdateIssue as StaticListMetadata<ListId>;
 }
 
 function sortLocalRows(rows: StoredLocalRow[]): StoredLocalRow[] {
@@ -281,6 +304,7 @@ export class StaticListsService {
   private readonly pollableRemoteStagingSummaryByListId: Readonly<
     Record<StaticListId, Pollable<StaticListSummary | undefined>>
   >;
+  private readonly pollableDataIssueState: Pollable<StaticListsDataIssueState>;
   private readonly pollableListUpdatedAtByListId: Readonly<
     Record<StaticListId, Pollable<IsoDateTime | undefined>>
   >;
@@ -335,6 +359,10 @@ export class StaticListsService {
     this.pollableListUpdatedAtByListId =
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the constructor fully populates each per-list pollable map before freezing it onto readonly fields
       pollableListUpdatedAtByListId as typeof this.pollableListUpdatedAtByListId;
+
+    this.pollableDataIssueState = new Pollable<StaticListsDataIssueState>({
+      kind: "none",
+    });
   }
 
   [Symbol.dispose](): void {
@@ -615,6 +643,70 @@ export class StaticListsService {
     };
   }
 
+  private async recordRemoteUpdateIssue({
+    error,
+    listId,
+    stage,
+    upstreamInfo,
+  }: {
+    error: unknown;
+    listId: StaticListId;
+    stage: StaticListRemoteUpdateIssueStage;
+    upstreamInfo: StaticListUpstreamInfo;
+  }): Promise<boolean> {
+    if (!isQuotaExceededRemoteUpdateError(error)) {
+      return false;
+    }
+
+    const issue: StaticListRemoteUpdateIssue = {
+      failedAt: isoDateTimeSchema.parse(Date.now()),
+      kind: "quotaExceeded",
+      stage,
+      upstreamInfo,
+    };
+
+    const context = await this.ensureListContext(listId);
+    await context.databases.deleteRemoteDatabase(
+      pickAnotherRemoteInstance(context.metadata.remoteActiveInstance),
+    );
+
+    await this.persistMetadata(
+      listId,
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id while preserving the current list-specific metadata shape
+      {
+        ...omitRemoteStaging(context.metadata),
+        remoteUpdateIssue: issue,
+      } as StaticListMetadata,
+    );
+
+    return true;
+  }
+
+  private async prepareBlockedRemoteUpdateRetry(
+    listId: StaticListId,
+    options?: { deleteActiveCache?: boolean },
+  ): Promise<void> {
+    const context = await this.ensureListContext(listId);
+    let nextMetadata = omitRemoteUpdateIssue(
+      omitRemoteStaging(context.metadata),
+    );
+
+    if (context.metadata.remoteStaging) {
+      await context.databases.deleteRemoteDatabase(
+        pickAnotherRemoteInstance(context.metadata.remoteActiveInstance),
+      );
+    }
+
+    if (options?.deleteActiveCache && context.metadata.remoteActive) {
+      await context.databases.deleteRemoteDatabase(
+        context.metadata.remoteActiveInstance,
+      );
+      nextMetadata = omitRemoteActive(nextMetadata);
+    }
+
+    await this.persistMetadata(listId, nextMetadata);
+  }
+
   /**
    * Initialization is where we reconcile persisted metadata with the actual
    * databases on disk.
@@ -876,6 +968,13 @@ export class StaticListsService {
     );
     this.pollableListUpdatedAtByListId[listId].setValue(
       extractUpdatedAtFromMetadata(metadata),
+    );
+    this.pollableDataIssueState.setValue(
+      deriveStaticListsDataIssueState(
+        [...this.contextByListId.values()].map(
+          ({ metadata: currentMetadata }) => currentMetadata,
+        ),
+      ),
     );
 
     if (metadata.combiningMode === "remoteOnly") {
@@ -1284,6 +1383,20 @@ export class StaticListsService {
     return result.value;
   }
 
+  public async pollDataIssueState(
+    lastPollVersion: PollVersion | undefined,
+  ): Promise<PollResult<StaticListsDataIssueState>> {
+    await Promise.all(
+      staticListIds.map(async (listId) => this.ensureListContext(listId)),
+    );
+    return await this.pollableDataIssueState.poll(lastPollVersion);
+  }
+
+  public async getDataIssueState(): Promise<StaticListsDataIssueState> {
+    const result = await this.pollDataIssueState(undefined);
+    return result.value;
+  }
+
   public async getRemoteListSummary<ListId extends StaticListId>(
     listId: ListId,
   ): Promise<StaticListSummary<ListId>> {
@@ -1413,20 +1526,33 @@ export class StaticListsService {
     );
   }
 
-  private async populateListIfOutdatedInternal(
+  private async populateRemoteList(
     listId: StaticListId,
     toleranceInMinutes: number | undefined,
+    options?: PopulateRemoteListOptions,
   ): Promise<PopulateFromUrlIfOutdatedResult> {
     const listLogger = this.getListLogger(listId);
     const context = await this.ensureListContext(listId);
     const rootConfig = await this.rootConfigService.get();
     const upstreamInfo =
       rootConfig.remoteSystemLookup.staticApi.listLookup[listId];
+    const metadata = this.getCurrentMetadata(listId);
 
     if (
+      metadata.remoteUpdateIssue?.kind === "quotaExceeded" &&
+      !options?.allowBlockedRetry
+    ) {
+      listLogger.info(
+        "Skipping automatic remote update because quota-blocked state is active",
+      );
+      return { success: true, data: "updateNotNeeded" };
+    }
+
+    if (
+      !options?.forcePopulate &&
       !this.needsRemoteUpdate({
         listId,
-        metadata: context.metadata,
+        metadata,
         toleranceInMinutes,
         upstreamGeneratedAt: upstreamInfo.generatedAt,
       })
@@ -1434,24 +1560,33 @@ export class StaticListsService {
       return { success: true, data: "updateNotNeeded" };
     }
 
+    if (options?.allowBlockedRetry) {
+      await this.prepareBlockedRemoteUpdateRetry(
+        listId,
+        options.deleteActiveCache ? { deleteActiveCache: true } : undefined,
+      );
+    }
+
     let shouldForceFreshRestart = false;
+    let currentStage: StaticListRemoteUpdateIssueStage = "createStaging";
 
     for (;;) {
-      const stagingSession = shouldForceFreshRestart
-        ? await this.createFreshRemoteStaging(listId, upstreamInfo)
-        : ((await this.tryResumeRemoteStaging(listId, upstreamInfo)) ??
-          (await this.createFreshRemoteStaging(listId, upstreamInfo)));
-
-      const {
-        activeInstance,
-        mutableStagingSummary,
-        resumedHeadLineNumber,
-        startedAtIso,
-        targetInstance,
-        targetTable,
-      } = stagingSession;
-
       try {
+        currentStage = "createStaging";
+        const stagingSession = shouldForceFreshRestart
+          ? await this.createFreshRemoteStaging(listId, upstreamInfo)
+          : ((await this.tryResumeRemoteStaging(listId, upstreamInfo)) ??
+            (await this.createFreshRemoteStaging(listId, upstreamInfo)));
+
+        const {
+          activeInstance,
+          mutableStagingSummary,
+          resumedHeadLineNumber,
+          startedAtIso,
+          targetInstance,
+          targetTable,
+        } = stagingSession;
+
         const fetchResult = await fetchFromRemoteSystem({
           aliasManager: this.aliasManagerForStaticApi,
           urlSuffix: `/lists/${listId}.jsonl`,
@@ -1486,6 +1621,7 @@ export class StaticListsService {
             return;
           }
 
+          currentStage = "writeRows";
           const durableLineNumber = rowsToStore.at(-1)?.r ?? 0;
           storedBatchCount += 1;
           storedRowCount += rowsToStore.length;
@@ -1602,6 +1738,7 @@ export class StaticListsService {
         }
 
         await flushBatch(false);
+        currentStage = "promote";
 
         await this.promoteRemoteStaging({
           activeInstance,
@@ -1630,6 +1767,23 @@ export class StaticListsService {
         return { success: true, data: "updated" };
       } catch (error) {
         const errorMessage = getErrorMessage(error);
+
+        if (
+          await this.recordRemoteUpdateIssue({
+            error,
+            listId,
+            stage: currentStage,
+            upstreamInfo,
+          })
+        ) {
+          listLogger.error(
+            "Remote update is paused because storage quota was exceeded during {stage}: {error}",
+            { error: errorMessage, stage: currentStage },
+          );
+
+          return { success: false, error: errorMessage };
+        }
+
         listLogger.error("Unexpected error while populating: {error}", {
           error: errorMessage,
         });
@@ -1639,18 +1793,20 @@ export class StaticListsService {
     }
   }
 
-  public async populateListIfOutdated(
+  private async runRemotePopulateWithDeduping(
     listId: StaticListId,
     toleranceInMinutes: number | undefined,
+    options?: PopulateRemoteListOptions,
   ): Promise<PopulateFromUrlIfOutdatedResult> {
     const existingPromise = this.updatePromiseByListId.get(listId);
     if (existingPromise) {
       return await existingPromise;
     }
 
-    const updatePromise = this.populateListIfOutdatedInternal(
+    const updatePromise = this.populateRemoteList(
       listId,
       toleranceInMinutes,
+      options,
     ).finally(() => {
       this.updatePromiseByListId.delete(listId);
     });
@@ -1659,12 +1815,19 @@ export class StaticListsService {
     return await updatePromise;
   }
 
+  public async populateListIfOutdated(
+    listId: StaticListId,
+    toleranceInMinutes: number | undefined,
+  ): Promise<PopulateFromUrlIfOutdatedResult> {
+    return await this.runRemotePopulateWithDeduping(listId, toleranceInMinutes);
+  }
+
   public updateIfNeeded(payload?: {
     listIds?: StaticListId[] | undefined;
     toleranceInMinutes?: number | undefined;
   }): void {
     for (const listId of payload?.listIds ?? staticListIds) {
-      void this.populateListIfOutdated(
+      void this.runRemotePopulateWithDeduping(
         listId,
         payload?.toleranceInMinutes,
       ).catch((error: unknown) => {
@@ -1676,6 +1839,31 @@ export class StaticListsService {
         );
       });
     }
+  }
+
+  public async retryBlockedRemoteUpdates(payload?: {
+    deleteActiveCache?: boolean;
+  }): Promise<void> {
+    await Promise.all(
+      staticListIds.map(async (listId) => this.ensureListContext(listId)),
+    );
+
+    await Promise.all(
+      staticListIds.map(async (listId) => {
+        const metadata = this.getCurrentMetadata(listId);
+        if (metadata.remoteUpdateIssue?.kind !== "quotaExceeded") {
+          return;
+        }
+
+        await this.runRemotePopulateWithDeduping(listId, undefined, {
+          allowBlockedRetry: true,
+          deleteActiveCache:
+            payload?.deleteActiveCache === true &&
+            Boolean(metadata.remoteActive),
+          forcePopulate: true,
+        });
+      }),
+    );
   }
 
   private prepareLocalRow(

--- a/src/entrypoints/background/@services/static-lists-service/data-issue-state.test.ts
+++ b/src/entrypoints/background/@services/static-lists-service/data-issue-state.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import type { StaticListMetadata } from "@/shared/@model/static-list-metadata";
+import { isoDateTimeSchema } from "@/shared/@primitives/temporal";
+
+import { deriveStaticListsDataIssueState } from "./data-issue-state";
+
+function createMetadata({
+  hasRemoteActive = false,
+  hasRemoteUpdateIssue = false,
+}: {
+  hasRemoteActive?: boolean;
+  hasRemoteUpdateIssue?: boolean;
+} = {}): StaticListMetadata<"announcements"> {
+  return {
+    listId: "announcements",
+    physicalStorageVersion: 1,
+    derivedDataVersion: "test",
+    combiningMode: "remoteOnly",
+    remoteActiveInstance: "b",
+    ...(hasRemoteActive
+      ? {
+          remoteActive: {
+            startedAt: isoDateTimeSchema.parse("2026-03-29T10:00:00.000Z"),
+            summary: { itemCount: 10 },
+            updatedAt: isoDateTimeSchema.parse("2026-03-29T10:00:01.000Z"),
+            upstreamInfo: {
+              generatedAt: isoDateTimeSchema.parse("2026-03-29T10:00:00.000Z"),
+              itemCount: 10,
+            },
+          },
+        }
+      : {}),
+    ...(hasRemoteUpdateIssue
+      ? {
+          remoteUpdateIssue: {
+            failedAt: isoDateTimeSchema.parse("2026-03-29T10:05:00.000Z"),
+            kind: "quotaExceeded",
+            stage: "writeRows",
+            upstreamInfo: {
+              generatedAt: isoDateTimeSchema.parse("2026-03-29T10:04:00.000Z"),
+              itemCount: 12,
+            },
+          },
+        }
+      : {}),
+  };
+}
+
+describe("deriveStaticListsDataIssueState", () => {
+  it("returns none when no lists are quota-blocked", () => {
+    expect(
+      deriveStaticListsDataIssueState([
+        createMetadata({ hasRemoteActive: true }),
+        createMetadata(),
+      ]),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("treats blocked lists without active data as unavailable", () => {
+    expect(
+      deriveStaticListsDataIssueState([
+        createMetadata({ hasRemoteUpdateIssue: true }),
+      ]),
+    ).toEqual({ kind: "initialDataUnavailable" });
+  });
+
+  it("treats blocked lists with active data as stale-but-usable", () => {
+    expect(
+      deriveStaticListsDataIssueState([
+        createMetadata({
+          hasRemoteActive: true,
+          hasRemoteUpdateIssue: true,
+        }),
+      ]),
+    ).toEqual({ kind: "updatesBlockedButExistingDataUsable" });
+  });
+
+  it("prioritizes unavailable data when blocked states are mixed", () => {
+    expect(
+      deriveStaticListsDataIssueState([
+        createMetadata({
+          hasRemoteActive: true,
+          hasRemoteUpdateIssue: true,
+        }),
+        createMetadata({ hasRemoteUpdateIssue: true }),
+      ]),
+    ).toEqual({ kind: "initialDataUnavailable" });
+  });
+});

--- a/src/entrypoints/background/@services/static-lists-service/data-issue-state.ts
+++ b/src/entrypoints/background/@services/static-lists-service/data-issue-state.ts
@@ -1,0 +1,20 @@
+import type { StaticListMetadata } from "@/shared/@model/static-list-metadata";
+import type { StaticListsDataIssueState } from "@/shared/@model/static-lists";
+
+export function deriveStaticListsDataIssueState(
+  metadataList: readonly StaticListMetadata[],
+): StaticListsDataIssueState {
+  const blockedMetadataList = metadataList.filter(
+    (metadata) => metadata.remoteUpdateIssue?.kind === "quotaExceeded",
+  );
+
+  if (blockedMetadataList.length === 0) {
+    return { kind: "none" };
+  }
+
+  if (blockedMetadataList.some((metadata) => !metadata.remoteActive)) {
+    return { kind: "initialDataUnavailable" };
+  }
+
+  return { kind: "updatesBlockedButExistingDataUsable" };
+}

--- a/src/entrypoints/background/@services/static-lists-service/remote-update-issue-helpers.test.ts
+++ b/src/entrypoints/background/@services/static-lists-service/remote-update-issue-helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { isQuotaExceededRemoteUpdateError } from "./remote-update-issue-helpers";
+
+describe("isQuotaExceededRemoteUpdateError", () => {
+  it("recognizes quota errors by name", () => {
+    expect(
+      isQuotaExceededRemoteUpdateError({
+        message: "Failed to execute transaction",
+        name: "QuotaExceededError",
+      }),
+    ).toBe(true);
+  });
+
+  it("recognizes quota errors nested in causes", () => {
+    expect(
+      isQuotaExceededRemoteUpdateError(
+        new Error("Outer failure", {
+          cause: { message: "There was not enough remaining storage space." },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat unrelated errors as quota failures", () => {
+    expect(
+      isQuotaExceededRemoteUpdateError(
+        new Error("Network request failed with 500"),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/entrypoints/background/@services/static-lists-service/remote-update-issue-helpers.ts
+++ b/src/entrypoints/background/@services/static-lists-service/remote-update-issue-helpers.ts
@@ -1,0 +1,73 @@
+function* walkErrorChain(
+  error: unknown,
+  seen = new Set(),
+): Generator<unknown, void, unknown> {
+  if (error === undefined || error === null || seen.has(error)) {
+    return;
+  }
+
+  if (typeof error !== "object" && !(error instanceof Error)) {
+    return;
+  }
+
+  seen.add(error);
+  yield error;
+
+  const candidate = error;
+  const cause = "cause" in candidate ? candidate.cause : undefined;
+  const inner = "inner" in candidate ? candidate.inner : undefined;
+  const innerError =
+    "innerError" in candidate ? candidate.innerError : undefined;
+  const errors = "errors" in candidate ? candidate.errors : undefined;
+
+  for (const nestedError of [cause, inner, innerError]) {
+    yield* walkErrorChain(nestedError, seen);
+  }
+
+  if (Array.isArray(errors)) {
+    for (const nestedError of errors) {
+      yield* walkErrorChain(nestedError, seen);
+    }
+  }
+}
+
+function extractErrorName(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("name" in error)) {
+    return undefined;
+  }
+
+  return typeof error.name === "string" ? error.name : undefined;
+}
+
+function extractErrorMessage(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("message" in error)) {
+    return undefined;
+  }
+
+  return typeof error.message === "string" ? error.message : undefined;
+}
+
+export function isQuotaExceededRemoteUpdateError(error: unknown): boolean {
+  for (const currentError of walkErrorChain(error)) {
+    const errorName = extractErrorName(currentError);
+    if (errorName === "QuotaExceededError") {
+      return true;
+    }
+
+    const errorMessage = extractErrorMessage(currentError)?.toLowerCase();
+    if (!errorMessage) {
+      continue;
+    }
+
+    if (
+      errorMessage.includes("quota") ||
+      errorMessage.includes("not enough space") ||
+      errorMessage.includes("storage full") ||
+      errorMessage.includes("remaining storage space")
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/entrypoints/content/in-page-app/toasts.tsx
+++ b/src/entrypoints/content/in-page-app/toasts.tsx
@@ -6,6 +6,7 @@ import {
   useExtensionVersionInfo,
   useFilteredAnnouncements,
   useGlobalNotificationsState,
+  useStaticListsDataIssueState,
 } from "@/shared/@ui-helpers/data-hooks";
 import {
   notificationService,
@@ -16,6 +17,7 @@ import { useContentId } from "../content-id-context";
 import { ToastWithAnnouncement } from "./toasts/toast-with-announcement";
 import { ToastWithDataWarmup } from "./toasts/toast-with-data-warmup";
 import { ToastWithDeprecatedExtensionVersion } from "./toasts/toast-with-deprecated-extension-version";
+import { ToastWithStaticDataIssue } from "./toasts/toast-with-static-data-issue";
 import { ToastWithTriggeredNotification } from "./toasts/toast-with-triggered-notification";
 import { ToastWithWelcomeMessage } from "./toasts/toast-with-welcome-message";
 
@@ -39,6 +41,71 @@ const useTriggeredNotification = createPollableValueHook(
     notificationService.pollTriggeredNotification(lastPollVersion, contentId),
   { hookNameForDebugging: "useTriggeredNotification" },
 );
+
+function ToastsAfterTriggeredNotification({
+  announcements,
+  announcementReadAtByCreatedAt,
+  dataWarmupToastNeeded,
+  extensionVersionInfo,
+  onDataWarmupDone,
+  welcomeMessageReadAt,
+}: {
+  announcements: ReturnType<typeof useFilteredAnnouncements>;
+  announcementReadAtByCreatedAt: Record<string, string | undefined>;
+  dataWarmupToastNeeded: boolean;
+  extensionVersionInfo: ReturnType<typeof useExtensionVersionInfo>;
+  onDataWarmupDone: () => void;
+  welcomeMessageReadAt: string | undefined;
+}) {
+  const dataIssueState = useStaticListsDataIssueState();
+
+  if (dataIssueState.kind === "initialDataUnavailable") {
+    return <ToastWithStaticDataIssue />;
+  }
+
+  if (!welcomeMessageReadAt) {
+    return <ToastWithWelcomeMessage />;
+  }
+
+  if (dataWarmupToastNeeded) {
+    return (
+      <ToastWithDataWarmup
+        onDone={() => {
+          onDataWarmupDone();
+        }}
+      />
+    );
+  }
+
+  const announcementToShow = announcements
+    // Show older announcements first
+    .toSorted((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .find(
+      ({ createdAt }) =>
+        !announcementReadAtByCreatedAt[createdAt] &&
+        createdAt > welcomeMessageReadAt,
+    );
+
+  if (announcementToShow) {
+    return (
+      <ToastWithAnnouncement
+        key={announcementToShow.createdAt}
+        {...announcementToShow}
+      />
+    );
+  }
+
+  if (extensionVersionInfo.deprecation) {
+    return (
+      <ToastWithDeprecatedExtensionVersion
+        {...extensionVersionInfo}
+        deprecation={extensionVersionInfo.deprecation}
+      />
+    );
+  }
+
+  return;
+}
 
 export function Toasts() {
   const announcements = useFilteredAnnouncements("toast");
@@ -93,54 +160,18 @@ export function Toasts() {
     );
   }
 
-  if (!welcomeMessageReadAt) {
-    return (
-      <React.Suspense>
-        <ToastWithWelcomeMessage />
-      </React.Suspense>
-    );
-  }
-
-  if (dataWarmupToastNeeded) {
-    return (
-      <React.Suspense>
-        <ToastWithDataWarmup
-          onDone={() => {
-            setDataWarmupToastNeeded(false);
-          }}
-        />
-      </React.Suspense>
-    );
-  }
-
-  const announcementToShow = announcements
-    // Show older announcements first
-    .toSorted((a, b) => a.createdAt.localeCompare(b.createdAt))
-    .find(
-      ({ createdAt }) =>
-        !announcementReadAtByCreatedAt[createdAt] &&
-        createdAt > welcomeMessageReadAt,
-    );
-
-  if (announcementToShow) {
-    return (
-      <ToastWithAnnouncement
-        key={announcementToShow.createdAt}
-        {...announcementToShow}
+  return (
+    <React.Suspense>
+      <ToastsAfterTriggeredNotification
+        announcements={announcements}
+        announcementReadAtByCreatedAt={announcementReadAtByCreatedAt}
+        dataWarmupToastNeeded={dataWarmupToastNeeded}
+        extensionVersionInfo={extensionVersionInfo}
+        onDataWarmupDone={() => {
+          setDataWarmupToastNeeded(false);
+        }}
+        welcomeMessageReadAt={welcomeMessageReadAt}
       />
-    );
-  }
-
-  if (extensionVersionInfo.deprecation) {
-    return (
-      <React.Suspense>
-        <ToastWithDeprecatedExtensionVersion
-          {...extensionVersionInfo}
-          deprecation={extensionVersionInfo.deprecation}
-        />
-      </React.Suspense>
-    );
-  }
-
-  return;
+    </React.Suspense>
+  );
 }

--- a/src/entrypoints/content/in-page-app/toasts/toast-with-static-data-issue.tsx
+++ b/src/entrypoints/content/in-page-app/toasts/toast-with-static-data-issue.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+import { ExtensionPopupLink } from "./shared/extension-popup-link";
+import { Toast } from "./toast";
+
+export function ToastWithStaticDataIssue() {
+  const [dismissed, setDismissed] = React.useState(false);
+
+  if (dismissed) {
+    return;
+  }
+
+  return (
+    <Toast
+      onClose={() => {
+        setDismissed(true);
+      }}
+    >
+      Не удалось загрузить данные: браузер выделил меньше места, чем ожидалось.
+      Подробнее —{" "}
+      <ExtensionPopupLink
+        onClick={() => {
+          setDismissed(true);
+        }}
+      />
+      .
+    </Toast>
+  );
+}

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -13,6 +13,7 @@ import { loggingService } from "@/shared/proxy-services";
 import { ActiveTab } from "./app/active-tab";
 import { Header } from "./app/header";
 import { Sidebar } from "./app/sidebar";
+import { StaticDataIssueBanner } from "./app/static-data-issue-banner";
 
 const logger = getPopupLogger();
 
@@ -55,6 +56,9 @@ function startPopupApp() {
         <TooltipProvider>
           <div className="absolute inset-0 flex flex-col">
             <Header />
+            <React.Suspense>
+              <StaticDataIssueBanner />
+            </React.Suspense>
             <div className="flex flex-1 overflow-hidden">
               <Sidebar />
               <ActiveTab />

--- a/src/entrypoints/popup/app/static-data-issue-banner.tsx
+++ b/src/entrypoints/popup/app/static-data-issue-banner.tsx
@@ -1,0 +1,100 @@
+import * as React from "react";
+
+import { useStaticListsDataIssueState } from "@/shared/@ui-helpers/data-hooks";
+import { Button } from "@/shared/@ui-primitives/button";
+import { staticListsService } from "@/shared/proxy-services";
+
+export function StaticDataIssueBanner() {
+  const dataIssueState = useStaticListsDataIssueState();
+  const [deleteCacheConfirmationShown, setDeleteCacheConfirmationShown] =
+    React.useState(false);
+  const deleteCacheConfirmationVisible =
+    deleteCacheConfirmationShown &&
+    dataIssueState.kind === "updatesBlockedButExistingDataUsable";
+
+  if (dataIssueState.kind === "none") {
+    return;
+  }
+
+  return (
+    <div
+      className="
+        border-y border-amber-500/20 bg-amber-500/10 px-3 pt-2.5 pb-4 text-sm
+        text-foreground
+        dark:border-amber-300/20 dark:bg-amber-300/10
+      "
+    >
+      <div className="space-y-2">
+        <p>
+          {dataIssueState.kind === "initialDataUnavailable" ? (
+            <>
+              Не удалось загрузить данные: браузер выделил меньше места, чем
+              ожидалось. Для быстрой подсветки ботов расширению нужно хранить
+              порядка 50 мегабайт на вашем устройстве.
+            </>
+          ) : (
+            <>
+              Не удалось обновить данные: браузер выделил меньше места, чем
+              ожидалось. Для быстрой подсветки ботов расширению нужно хранить
+              порядка 50 мегабайт на вашем устройстве. Во время обновления
+              данных потребление диска ненадолго возрастает.
+            </>
+          )}
+        </p>
+
+        {deleteCacheConfirmationVisible ? (
+          <div className="space-y-2">
+            <p className="text-destructive">
+              Очистить временно сохранённые данные и попробовать снова?
+              Подсветка ботов отключится на время обновления.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setDeleteCacheConfirmationShown(false);
+                }}
+              >
+                Отмена
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={() => {
+                  void staticListsService.retryBlockedRemoteUpdates({
+                    deleteActiveCache: true,
+                  });
+                }}
+              >
+                Очистить кэш и повторить
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            <Button
+              size="sm"
+              onClick={() => {
+                void staticListsService.retryBlockedRemoteUpdates();
+              }}
+            >
+              Повторить попытку
+            </Button>
+            {dataIssueState.kind === "updatesBlockedButExistingDataUsable" && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setDeleteCacheConfirmationShown(true);
+                }}
+              >
+                Очистить кэш и повторить
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/@model/static-list-helpers.ts
+++ b/src/shared/@model/static-list-helpers.ts
@@ -29,6 +29,29 @@ export type StaticListUpstreamInfo = z.infer<
   typeof staticListUpstreamInfoSchema
 >;
 
+export const staticListRemoteUpdateIssueStageSchema = z.enum([
+  "createStaging",
+  "writeRows",
+  "promote",
+]);
+export type StaticListRemoteUpdateIssueStage = z.infer<
+  typeof staticListRemoteUpdateIssueStageSchema
+>;
+
+export const staticListRemoteUpdateIssueKindSchema = z.enum(["quotaExceeded"]);
+
+export const staticListRemoteUpdateIssueSchema = z.readonly(
+  z.object({
+    failedAt: isoDateTimeSchema,
+    kind: staticListRemoteUpdateIssueKindSchema,
+    stage: staticListRemoteUpdateIssueStageSchema,
+    upstreamInfo: staticListUpstreamInfoSchema,
+  }),
+);
+export type StaticListRemoteUpdateIssue = z.infer<
+  typeof staticListRemoteUpdateIssueSchema
+>;
+
 export const staticListRemoteInstanceSchema = z.enum(["a", "b"]);
 export type StaticListRemoteInstance = z.infer<
   typeof staticListRemoteInstanceSchema

--- a/src/shared/@model/static-list-metadata.ts
+++ b/src/shared/@model/static-list-metadata.ts
@@ -4,6 +4,7 @@ import { isoDateTimeSchema } from "../@primitives/temporal";
 import {
   staticListCombiningModeSchema,
   staticListRemoteInstanceSchema,
+  staticListRemoteUpdateIssueSchema,
   staticListUpstreamInfoSchema,
 } from "./static-list-helpers";
 import {
@@ -50,6 +51,7 @@ export const staticListMetadataSchema = z.readonly(
         }),
       ),
     ),
+    remoteUpdateIssue: z.exactOptional(staticListRemoteUpdateIssueSchema),
     localUpdatedAt: z.exactOptional(isoDateTimeSchema),
   }),
 );

--- a/src/shared/@model/static-lists.ts
+++ b/src/shared/@model/static-lists.ts
@@ -46,6 +46,11 @@ export type StaticListItem<ListId extends StaticListId = StaticListId> =
 export type StaticListSummary<ListId extends StaticListId = StaticListId> =
   ListId extends StaticListId ? StaticListSummaryByListId[ListId] : never;
 
+export type StaticListsDataIssueState =
+  | { kind: "none" }
+  | { kind: "initialDataUnavailable" }
+  | { kind: "updatesBlockedButExistingDataUsable" };
+
 export type { AccountListItem } from "./static-lists/=accounts";
 export type { AnnouncementListItem } from "./static-lists/=announcements";
 export type { InsertionListItem } from "./static-lists/=insertions";

--- a/src/shared/@ui-helpers/data-hooks.ts
+++ b/src/shared/@ui-helpers/data-hooks.ts
@@ -117,6 +117,11 @@ export const useStaticListSummary = createPollableValueHook(
   { hookNameForDebugging: "useStaticListSummary", throttleInterval: 100 },
 ) as UseStaticListSummary;
 
+export const useStaticListsDataIssueState = createPollableValueHook(
+  (lastPollVersion) => staticListsService.pollDataIssueState(lastPollVersion),
+  { hookNameForDebugging: "useStaticListsDataIssueState" },
+);
+
 export const useUserConfig = createPollableValueHook(
   (lastPollVersion) => userConfigService.poll(lastPollVersion),
   { hookNameForDebugging: "useUserConfig" },


### PR DESCRIPTION
Добавлено сохранение quota-ошибок при скачивании статических списков. Если на устройстве пользователя не хватает места, мы останавливаем повторные попытки скачать списки. Пользователь видит тост и предупреждение в попапе. Без такой остановки безуспешные попытки скачать данные будут идти по кругу, тратя ресурсы и каждый раз упираясь в стену.

В реальности нехватка места для IndexedDB маловероятна, потому что расширение имеет `unlimitedStorage`. Чтобы поймать `QuotaExceededError` нужны либо какие-то экзотические настройки в браузере, либо крайне мало физического места на диске.

<img width="576" height="568" alt="Screenshot 2026-03-29 at 04 14 20" src="https://github.com/user-attachments/assets/2f0ca13d-cea8-4808-b947-4370639f3b0d" />

<img width="576" height="568" alt="Screenshot 2026-03-29 at 04 15 07" src="https://github.com/user-attachments/assets/1f943719-292c-421d-855d-06930fe18968" />

<img width="576" height="568" alt="Screenshot 2026-03-29 at 04 15 11" src="https://github.com/user-attachments/assets/e085d8f4-20cf-4e5a-a9bb-65e87d15f24a" />

<img width="576" height="568" alt="Screenshot 2026-03-29 at 04 15 24" src="https://github.com/user-attachments/assets/68029b99-0dd9-4eda-87bd-0a59ff7a0046" />

---

<img width="332" height="129" alt="Screenshot 2026-03-29 at 04 18 34" src="https://github.com/user-attachments/assets/3c2115f9-2dfa-4220-a500-023197bc08e2" />

Тост появляется на страницах ВК только если не удалось скачать данные в первый раз.

---

Симуляция проблемы:

1. Временно убрать unlimitedStorage из wxt.config.ts
2. Запустить `pnpm dev:chrome`
3. Открыть попап → Inspect → Application → Storage
4. Вручную задать крайне низкую квоту

<img width="602" height="400" alt="Screenshot 2026-03-29 at 03 29 55" src="https://github.com/user-attachments/assets/bdf226d8-5c15-48db-9456-4417688290a3" />
