### PR TITLE
Use updated-at polling for coarse static list checks

### DIFF
--- a/src/entrypoints/background/@services/collecting-service.ts
+++ b/src/entrypoints/background/@services/collecting-service.ts
@@ -156,7 +156,7 @@ export class CollectingService {
     void (async () => {
       let lastPollVersion: PollVersion | undefined;
       while (!this.disposed) {
-        const result = await staticListsService.pollListMetadata(
+        const result = await staticListsService.pollListUpdatedAt(
           lastPollVersion,
           "walls",
         );

--- a/src/entrypoints/content/in-page-app/toasts.tsx
+++ b/src/entrypoints/content/in-page-app/toasts.tsx
@@ -22,18 +22,14 @@ import { ToastWithTriggeredNotification } from "./toasts/toast-with-triggered-no
 import { ToastWithWelcomeMessage } from "./toasts/toast-with-welcome-message";
 
 export async function checkIfDataWarmupToastNeeded(): Promise<boolean> {
-  const [accountsMetadata, insertionsMetadata, tagsMetadata] =
+  const [accountsUpdatedAt, insertionsUpdatedAt, tagsUpdatedAt] =
     await Promise.all([
-      staticListsService.getListMetadata("accounts"),
-      staticListsService.getListMetadata("insertions"),
-      staticListsService.getListMetadata("tags"),
+      staticListsService.getListUpdatedAt("accounts"),
+      staticListsService.getListUpdatedAt("insertions"),
+      staticListsService.getListUpdatedAt("tags"),
     ]);
 
-  return (
-    !accountsMetadata.remoteActive ||
-    !insertionsMetadata.remoteActive ||
-    !tagsMetadata.remoteActive
-  );
+  return !accountsUpdatedAt || !insertionsUpdatedAt || !tagsUpdatedAt;
 }
 
 const useTriggeredNotification = createPollableValueHook(


### PR DESCRIPTION
Проверка метаданных списка заменена на проверку времени последнего обновления в двух местах. Это
- уменьшает количество реакт-обновлений в тостах
- уменьшает количество раз, когда нужно пересчитать состояние collecting service