### PR TITLE
Use list refresh time in popup header

### DIFF
--- a/src/entrypoints/popup/app/header.tsx
+++ b/src/entrypoints/popup/app/header.tsx
@@ -54,8 +54,8 @@ function AccountListMetadata() {
 
   return (
     <>
-      Список аккаунтов от{" "}
-      {formatDateTime(accountsMetadata.remoteActive.upstreamInfo.generatedAt)}
+      Список аккаунтов обновлён:{" "}
+      {formatDateTime(accountsMetadata.remoteActive.updatedAt)}
     </>
   );
 }


### PR DESCRIPTION
Заменён текст в заголовке попапа на «Список аккаунтов обновлён: …». Теперь в нём показывается время фактического обновления списка через remoteActive.updatedAt, а не upstream generatedAt.

<img width="498" height="501" alt="Screenshot 2026-03-29 at 22 21 28" src="https://github.com/user-attachments/assets/179a5325-1d1f-4127-aa9c-bbb0b6ee60ff" />
