### PR TITLE
Fix async dispose in logging service sink

### DIFF
--- a/src/shared/@logging/logging-service-sink.ts
+++ b/src/shared/@logging/logging-service-sink.ts
@@ -96,7 +96,7 @@ export function createLoggingServiceSink(
   }
 
   return Object.assign(sink, {
-    [Symbol.dispose]: async () => {
+    [Symbol.dispose]: () => {
       disposed = true;
 
       if (flushTimer) {
@@ -104,7 +104,7 @@ export function createLoggingServiceSink(
         flushTimer = undefined;
       }
 
-      await flush();
+      void flush();
     },
   });
 }


### PR DESCRIPTION
Closes https://github.com/botnadzor/extension/issues/150

Метод `Symbol.dispose` был помечен как async, что приводило к возврату Promise. LogTape обнаруживал это и выбрасывал ConfigureError при вызове configureSync(), из-за чего расширение не запускалось вовсе.

Убрали async и заменили await flush() на void flush() — сброс буфера по-прежнему происходит в фоне, но dispose теперь синхронный, как и требует Disposable.

