### PR TITLE
Add description template to CD release drafts

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -25,6 +25,11 @@ jobs:
           run-id: ${{ inputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
       - name: Prepare release metadata
         id: prepare
         run: |
@@ -40,6 +45,47 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
 
+          ## Find previous tags by walking git ancestry.
+          ## git tag --merged TAG^ lists all tags reachable from TAG's parent,
+          ## sorted descending by version — the first match is the closest ancestor.
+          ANCESTOR_TAGS=$(git tag --merged "${TAG}^" --sort=-version:refname 2>/dev/null || true)
+
+          ## Previous stable release: first ancestor matching vX.Y.Z exactly
+          PREV_STABLE=$(echo "$ANCESTOR_TAGS" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+          ## Previous pre-release of the same series (e.g. v2.0.0-beta for v2.0.0-beta.2)
+          PREV_PRE=""
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-.+$ ]]; then
+            PRE_SERIES=$(echo "$TAG" | sed -E 's/^(v[0-9]+\.[0-9]+\.[0-9]+-[^.]+)\.[0-9]+$/\1/')
+            if [[ "$PRE_SERIES" != "$TAG" ]]; then
+              PREV_PRE=$(echo "$ANCESTOR_TAGS" | grep -E "^${PRE_SERIES//./\\.}\.[0-9]+$" | head -1)
+            fi
+          fi
+
+          ## Build release notes body
+          REPO="botnadzor/extension"
+          INSTALL_URL="https://github.com/${REPO}#%D1%83%D1%81%D1%82%D0%B0%D0%BD%D0%BE%D0%B2%D0%BA%D0%B0-%D0%B8%D0%B7-%D0%BC%D0%B0%D0%B3%D0%B0%D0%B7%D0%B8%D0%BD%D0%B0-%D0%B1%D1%80%D0%B0%D1%83%D0%B7%D0%B5%D1%80%D0%B0"
+
+          if [[ -n "$PREV_STABLE" ]]; then
+            if [[ -n "$PREV_PRE" ]]; then
+              DIFF_LINE="[Разница с ${PREV_STABLE}](https://github.com/${REPO}/compare/${PREV_STABLE}...${TAG}) • [${PREV_PRE}](https://github.com/${REPO}/compare/${PREV_PRE}...${TAG})  "
+            else
+              DIFF_LINE="[Разница с ${PREV_STABLE}](https://github.com/${REPO}/compare/${PREV_STABLE}...${TAG})  "
+            fi
+          else
+            DIFF_LINE=""
+          fi
+
+          {
+            echo "notes<<NOTES_EOF"
+            printf '%s\n' "<!--"
+            printf '%s\n' "Анонс:  [Сайт](https://botnadzor.org/news/??) • [TG](https://t.me/botnadzor_org/??) • [VK](https://vk.com/wall-187686148_??)"
+            printf '%s\n' "-->"
+            [[ -n "$DIFF_LINE" ]] && printf '%s\n' "$DIFF_LINE"
+            printf '%s\n' "[Инструкция по установке](${INSTALL_URL})"
+            echo "NOTES_EOF"
+          } >> $GITHUB_OUTPUT
+
       - name: Create release draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -53,5 +99,6 @@ jobs:
           gh release create "${{ steps.prepare.outputs.tag }}" \
             --draft \
             --title "${{ steps.prepare.outputs.title }}" \
+            --notes "${{ steps.prepare.outputs.notes }}" \
             $PRERELEASE_FLAG \
             release-zips/*.zip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,7 +154,7 @@ jobs:
     name: Lint and Test
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-24.04' }}
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm

--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm

--- a/cspell-words.txt
+++ b/cspell-words.txt
@@ -47,6 +47,7 @@ roledescription
 rowsmembers
 rsc
 rt_russian
+sed
 sel
 shadcn
 showmoretext


### PR DESCRIPTION
Добавлен шаблон описания в черновики релизов.

Перед созданием черновика workflow теперь:
- делает checkout репозитория с полной историей;
- находит предыдущий стабильный тег через `git tag --merged`, идя по истории от родителя текущего тега;
- для пре-релизов дополнительно ищет предыдущий пре-релиз той же серии (например, `v2.0.0-beta.1` для `v2.0.0-beta.2`);
- формирует тело описания: блок-комментарий с заглушками ссылок на анонс, ссылка на diff с предыдущим релизом (и опционально с предыдущим пре-релизом), ссылка на инструкцию по установке.