### PR TITLE
Add bounded heartbeat for static list staging

### DIFF
--- a/src/entrypoints/background/@services/static-lists-service.ts
+++ b/src/entrypoints/background/@services/static-lists-service.ts
@@ -34,6 +34,7 @@ import {
 import type { AliasManager } from "../@service-helpers/alias-manager";
 import { fetchFromRemoteSystem } from "../@service-helpers/fetch-from-remote-system";
 import type { RootConfigService } from "./root-config-service";
+import { withBackgroundHeartbeat } from "./static-lists-service/background-heartbeat";
 import { deriveStaticListsDataIssueState } from "./static-lists-service/data-issue-state";
 import {
   getStaticListDefinitionInfo,
@@ -1567,230 +1568,240 @@ export class StaticListsService {
       );
     }
 
-    let shouldForceFreshRestart = false;
-    let currentStage: StaticListRemoteUpdateIssueStage = "createStaging";
+    return await withBackgroundHeartbeat(async () => {
+      // This update path can spend minutes streaming and check-pointing very
+      // large resumable lists. We wrap only this bounded task in a documented
+      // MV3-style heartbeat so the background is less likely to be culled mid-
+      // transfer. The staging logic remains resumable without this helper, so
+      // this is strictly an optimization, not a correctness requirement.
+      let shouldForceFreshRestart = false;
+      let currentStage: StaticListRemoteUpdateIssueStage = "createStaging";
 
-    for (;;) {
-      try {
-        currentStage = "createStaging";
-        const stagingSession = shouldForceFreshRestart
-          ? await this.createFreshRemoteStaging(listId, upstreamInfo)
-          : ((await this.tryResumeRemoteStaging(listId, upstreamInfo)) ??
-            (await this.createFreshRemoteStaging(listId, upstreamInfo)));
+      for (;;) {
+        try {
+          currentStage = "createStaging";
+          const stagingSession = shouldForceFreshRestart
+            ? await this.createFreshRemoteStaging(listId, upstreamInfo)
+            : ((await this.tryResumeRemoteStaging(listId, upstreamInfo)) ??
+              (await this.createFreshRemoteStaging(listId, upstreamInfo)));
 
-        const {
-          activeInstance,
-          mutableStagingSummary,
-          resumedHeadLineNumber,
-          startedAtIso,
-          targetInstance,
-          targetTable,
-        } = stagingSession;
+          const {
+            activeInstance,
+            mutableStagingSummary,
+            resumedHeadLineNumber,
+            startedAtIso,
+            targetInstance,
+            targetTable,
+          } = stagingSession;
 
-        const fetchResult = await fetchFromRemoteSystem({
-          aliasManager: this.aliasManagerForStaticApi,
-          urlSuffix: `/lists/${listId}.jsonl`,
-        });
+          const fetchResult = await fetchFromRemoteSystem({
+            aliasManager: this.aliasManagerForStaticApi,
+            urlSuffix: `/lists/${listId}.jsonl`,
+          });
 
-        if (!fetchResult.success) {
-          return {
-            success: false,
-            error: `Failed to fetch list from static API (reason: ${fetchResult.reason})`,
+          if (!fetchResult.success) {
+            return {
+              success: false,
+              error: `Failed to fetch list from static API (reason: ${fetchResult.reason})`,
+            };
+          }
+
+          if (fetchResult.response.status !== 200) {
+            return {
+              success: false,
+              error: `Failed to fetch list from static API: ${fetchResult.response.status}`,
+            };
+          }
+
+          if (!fetchResult.response.body) {
+            return {
+              success: false,
+              error: "No response body from static API",
+            };
+          }
+
+          let lineNumber = 0;
+          let storedBatchCount = 0;
+          let storedRowCount = 0;
+          let rowsToStore: StoredRemoteRow[] = [];
+          let restartFreshReason: string | undefined;
+
+          const flushBatch = async (shouldPersistStagingProgress: boolean) => {
+            if (rowsToStore.length === 0) {
+              return;
+            }
+
+            currentStage = "writeRows";
+            const durableLineNumber = rowsToStore.at(-1)?.r ?? 0;
+            storedBatchCount += 1;
+            storedRowCount += rowsToStore.length;
+            await targetTable.bulkPut(rowsToStore);
+            rowsToStore = [];
+
+            if (!shouldPersistStagingProgress) {
+              return;
+            }
+
+            const currentMetadata = this.getCurrentMetadata(listId);
+            if (!currentMetadata.remoteStaging) {
+              return;
+            }
+
+            await this.persistMetadata(
+              listId,
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
+              {
+                ...currentMetadata,
+                remoteStaging: {
+                  ...currentMetadata.remoteStaging,
+                  durableLineNumber,
+                  updatedAt: isoDateTimeSchema.parse(Date.now()),
+                  summary: structuredClone(mutableStagingSummary),
+                },
+              } as StaticListMetadata,
+            );
           };
-        }
 
-        if (fetchResult.response.status !== 200) {
-          return {
-            success: false,
-            error: `Failed to fetch list from static API: ${fetchResult.response.status}`,
-          };
-        }
+          for await (const line of streamLines(fetchResult.response.body)) {
+            lineNumber += 1;
 
-        if (!fetchResult.response.body) {
-          return { success: false, error: "No response body from static API" };
-        }
+            if (lineNumber <= resumedHeadLineNumber) {
+              if (
+                !shouldVerifyResumedLine({
+                  durableLineNumber: resumedHeadLineNumber,
+                  lineNumber,
+                  stride: resumeVerificationStride,
+                })
+              ) {
+                continue;
+              }
 
-        let lineNumber = 0;
-        let storedBatchCount = 0;
-        let storedRowCount = 0;
-        let rowsToStore: StoredRemoteRow[] = [];
-        let restartFreshReason: string | undefined;
+              const stagedRow = await targetTable
+                .where("r")
+                .equals(lineNumber)
+                .first();
 
-        const flushBatch = async (shouldPersistStagingProgress: boolean) => {
-          if (rowsToStore.length === 0) {
-            return;
-          }
+              if (!stagedRow) {
+                restartFreshReason = `Missing staged row at line ${lineNumber}`;
+                break;
+              }
 
-          currentStage = "writeRows";
-          const durableLineNumber = rowsToStore.at(-1)?.r ?? 0;
-          storedBatchCount += 1;
-          storedRowCount += rowsToStore.length;
-          await targetTable.bulkPut(rowsToStore);
-          rowsToStore = [];
+              if (stagedRow.t !== line) {
+                restartFreshReason = `Staged row content mismatch at line ${lineNumber}`;
+                break;
+              }
 
-          if (!shouldPersistStagingProgress) {
-            return;
-          }
-
-          const currentMetadata = this.getCurrentMetadata(listId);
-          if (!currentMetadata.remoteStaging) {
-            return;
-          }
-
-          await this.persistMetadata(
-            listId,
-            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- this runtime update path works with an erased list id, but the summary was built from that same list's definition
-            {
-              ...currentMetadata,
-              remoteStaging: {
-                ...currentMetadata.remoteStaging,
-                durableLineNumber,
-                updatedAt: isoDateTimeSchema.parse(Date.now()),
-                summary: structuredClone(mutableStagingSummary),
-              },
-            } as StaticListMetadata,
-          );
-        };
-
-        for await (const line of streamLines(fetchResult.response.body)) {
-          lineNumber += 1;
-
-          if (lineNumber <= resumedHeadLineNumber) {
-            if (
-              !shouldVerifyResumedLine({
-                durableLineNumber: resumedHeadLineNumber,
-                lineNumber,
-                stride: resumeVerificationStride,
-              })
-            ) {
               continue;
             }
 
-            const stagedRow = await targetTable
-              .where("r")
-              .equals(lineNumber)
-              .first();
+            const storedRow = createStoredRemoteRow({
+              listId,
+              lineNumber,
+              sourceText: line,
+            });
 
-            if (!stagedRow) {
-              restartFreshReason = `Missing staged row at line ${lineNumber}`;
-              break;
+            rowsToStore.push(storedRow);
+
+            const interpretedRow = interpretStoredRow(
+              listId,
+              storedRow,
+              "remote",
+            );
+            if (interpretedRow.interpretation.success) {
+              context.definitionInfo.definition.adjustSummary(
+                mutableStagingSummary,
+                interpretedRow.interpretation.item,
+                1,
+              );
             }
 
-            if (stagedRow.t !== line) {
-              restartFreshReason = `Staged row content mismatch at line ${lineNumber}`;
-              break;
+            if (rowsToStore.length >= itemBatchSize) {
+              await flushBatch(true);
+            }
+          }
+
+          if (!restartFreshReason && lineNumber < resumedHeadLineNumber) {
+            restartFreshReason = `Remote list ended at line ${lineNumber} before staged prefix ${resumedHeadLineNumber}`;
+          }
+
+          if (
+            !restartFreshReason &&
+            resumedHeadLineNumber === upstreamInfo.itemCount &&
+            lineNumber !== resumedHeadLineNumber
+          ) {
+            restartFreshReason = `Remote list length changed during direct promotion verification (${lineNumber} !== ${resumedHeadLineNumber})`;
+          }
+
+          if (restartFreshReason) {
+            listLogger.warn(
+              "Selective resume verification failed, discarding staging and retrying fresh: {reason}",
+              { reason: restartFreshReason },
+            );
+            await this.discardRemoteStaging(listId);
+
+            if (shouldForceFreshRestart) {
+              return { success: false, error: restartFreshReason };
             }
 
+            shouldForceFreshRestart = true;
             continue;
           }
 
-          const storedRow = createStoredRemoteRow({
+          await flushBatch(false);
+          currentStage = "promote";
+
+          await this.promoteRemoteStaging({
+            activeInstance,
             listId,
-            lineNumber,
-            sourceText: line,
+            startedAtIso,
+            summary: mutableStagingSummary,
+            targetInstance,
+            upstreamInfo,
           });
 
-          rowsToStore.push(storedRow);
-
-          const interpretedRow = interpretStoredRow(
-            listId,
-            storedRow,
-            "remote",
-          );
-          if (interpretedRow.interpretation.success) {
-            context.definitionInfo.definition.adjustSummary(
-              mutableStagingSummary,
-              interpretedRow.interpretation.item,
-              1,
+          if (resumedHeadLineNumber > 0 && storedRowCount === 0) {
+            listLogger.info(
+              "Verified and promoted completed staging without downloading new rows",
+            );
+          } else {
+            listLogger.info(
+              "Populated {storedRowCount} remote rows (batches: {storedBatchCount}, resumedFromLine: {resumedHeadLineNumber})",
+              {
+                resumedHeadLineNumber,
+                storedBatchCount,
+                storedRowCount,
+              },
             );
           }
 
-          if (rowsToStore.length >= itemBatchSize) {
-            await flushBatch(true);
-          }
-        }
+          return { success: true, data: "updated" };
+        } catch (error) {
+          const errorMessage = getErrorMessage(error);
 
-        if (!restartFreshReason && lineNumber < resumedHeadLineNumber) {
-          restartFreshReason = `Remote list ended at line ${lineNumber} before staged prefix ${resumedHeadLineNumber}`;
-        }
+          if (
+            await this.recordRemoteUpdateIssue({
+              error,
+              listId,
+              stage: currentStage,
+              upstreamInfo,
+            })
+          ) {
+            listLogger.error(
+              "Remote update is paused because storage quota was exceeded during {stage}: {error}",
+              { error: errorMessage, stage: currentStage },
+            );
 
-        if (
-          !restartFreshReason &&
-          resumedHeadLineNumber === upstreamInfo.itemCount &&
-          lineNumber !== resumedHeadLineNumber
-        ) {
-          restartFreshReason = `Remote list length changed during direct promotion verification (${lineNumber} !== ${resumedHeadLineNumber})`;
-        }
-
-        if (restartFreshReason) {
-          listLogger.warn(
-            "Selective resume verification failed, discarding staging and retrying fresh: {reason}",
-            { reason: restartFreshReason },
-          );
-          await this.discardRemoteStaging(listId);
-
-          if (shouldForceFreshRestart) {
-            return { success: false, error: restartFreshReason };
+            return { success: false, error: errorMessage };
           }
 
-          shouldForceFreshRestart = true;
-          continue;
-        }
-
-        await flushBatch(false);
-        currentStage = "promote";
-
-        await this.promoteRemoteStaging({
-          activeInstance,
-          listId,
-          startedAtIso,
-          summary: mutableStagingSummary,
-          targetInstance,
-          upstreamInfo,
-        });
-
-        if (resumedHeadLineNumber > 0 && storedRowCount === 0) {
-          listLogger.info(
-            "Verified and promoted completed staging without downloading new rows",
-          );
-        } else {
-          listLogger.info(
-            "Populated {storedRowCount} remote rows (batches: {storedBatchCount}, resumedFromLine: {resumedHeadLineNumber})",
-            {
-              resumedHeadLineNumber,
-              storedBatchCount,
-              storedRowCount,
-            },
-          );
-        }
-
-        return { success: true, data: "updated" };
-      } catch (error) {
-        const errorMessage = getErrorMessage(error);
-
-        if (
-          await this.recordRemoteUpdateIssue({
-            error,
-            listId,
-            stage: currentStage,
-            upstreamInfo,
-          })
-        ) {
-          listLogger.error(
-            "Remote update is paused because storage quota was exceeded during {stage}: {error}",
-            { error: errorMessage, stage: currentStage },
-          );
+          listLogger.error("Unexpected error while populating: {error}", {
+            error: errorMessage,
+          });
 
           return { success: false, error: errorMessage };
         }
-
-        listLogger.error("Unexpected error while populating: {error}", {
-          error: errorMessage,
-        });
-
-        return { success: false, error: errorMessage };
       }
-    }
+    });
   }
 
   private async runRemotePopulateWithDeduping(

--- a/src/entrypoints/background/@services/static-lists-service/background-heartbeat.test.ts
+++ b/src/entrypoints/background/@services/static-lists-service/background-heartbeat.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeState = vi.hoisted(() => ({
+  getPlatformInfo: vi.fn().mockResolvedValue({ os: "mac" }),
+}));
+
+vi.mock("#imports", () => ({
+  browser: {
+    runtime: {
+      getPlatformInfo: runtimeState.getPlatformInfo,
+    },
+  },
+}));
+
+const { backgroundHeartbeatIntervalInMs, withBackgroundHeartbeat } =
+  await import("./background-heartbeat");
+
+function createDeferred<T>() {
+  let resolvePromise!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: resolvePromise,
+  };
+}
+
+describe("withBackgroundHeartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    runtimeState.getPlatformInfo.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("pings the runtime while long-running work is in flight", async () => {
+    const deferred = createDeferred<string>();
+    const heartbeat = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    const resultPromise = withBackgroundHeartbeat(() => deferred.promise, {
+      heartbeat,
+      intervalInMs: backgroundHeartbeatIntervalInMs,
+    });
+
+    await vi.advanceTimersByTimeAsync(backgroundHeartbeatIntervalInMs);
+    expect(heartbeat).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(backgroundHeartbeatIntervalInMs);
+    expect(heartbeat).toHaveBeenCalledTimes(2);
+
+    deferred.resolve("done");
+    await expect(resultPromise).resolves.toBe("done");
+  });
+
+  it("cleans up its timer once the task settles", async () => {
+    const deferred = createDeferred<string>();
+    const heartbeat = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    const resultPromise = withBackgroundHeartbeat(() => deferred.promise, {
+      heartbeat,
+      intervalInMs: backgroundHeartbeatIntervalInMs,
+    });
+
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(backgroundHeartbeatIntervalInMs);
+    deferred.resolve("done");
+    await expect(resultPromise).resolves.toBe("done");
+
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(backgroundHeartbeatIntervalInMs);
+    expect(heartbeat).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fail the wrapped task when the heartbeat itself errors", async () => {
+    const heartbeat = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("ignored"));
+
+    const resultPromise = withBackgroundHeartbeat(
+      async () => {
+        await vi.advanceTimersByTimeAsync(backgroundHeartbeatIntervalInMs);
+        return "done";
+      },
+      { heartbeat, intervalInMs: backgroundHeartbeatIntervalInMs },
+    );
+
+    await expect(resultPromise).resolves.toBe("done");
+    expect(heartbeat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/entrypoints/background/@services/static-lists-service/background-heartbeat.ts
+++ b/src/entrypoints/background/@services/static-lists-service/background-heartbeat.ts
@@ -1,0 +1,60 @@
+import { browser } from "#imports";
+
+export const backgroundHeartbeatIntervalInMs = 25 * 1000;
+
+async function pingBackgroundHeartbeat(): Promise<void> {
+  await browser.runtime.getPlatformInfo();
+}
+
+/**
+ * Chrome's MV3 migration guide documents this waitUntil-style pattern for
+ * exceptional long-running tasks that may otherwise outlive the service
+ * worker's idle timeout.
+ *
+ * We intentionally use it only as a bounded reliability guard around one
+ * resumable static-list update task. This is not a general-purpose keepalive:
+ * the timer starts immediately before the work, stops in `finally`, and does not
+ * try to keep the background alive between tasks. In practice, the duration of
+ * the update is about 1-2 minutes.
+ *
+ * Reviewer context:
+ * - if the background is terminated during a large staging update, the
+ *   extension can resume from persisted progress, so correctness does not
+ *   depend on this helper
+ * - the helper exists only to reduce waste from repeatedly re-downloading and
+ *   re-verifying very large lists such as `accounts.jsonl`
+ * - the heartbeat uses a harmless extension API call (`runtime.getPlatformInfo`)
+ *   instead of hidden pages, persistent ports, or other longer-lived mechanisms
+ */
+export async function withBackgroundHeartbeat<Result>(
+  task: () => Promise<Result>,
+  options?: {
+    heartbeat?: () => Promise<unknown>;
+    intervalInMs?: number;
+  },
+): Promise<Result> {
+  const heartbeat = options?.heartbeat ?? pingBackgroundHeartbeat;
+  const intervalInMs = options?.intervalInMs ?? backgroundHeartbeatIntervalInMs;
+
+  let inFlightHeartbeat: Promise<void> | undefined;
+  const keepAliveTimer = setInterval(() => {
+    if (inFlightHeartbeat) {
+      return;
+    }
+
+    inFlightHeartbeat = Promise.resolve(heartbeat())
+      .catch(() => {
+        // Best-effort only: the download task itself remains authoritative.
+      })
+      .then(() => {
+        inFlightHeartbeat = undefined;
+      });
+  }, intervalInMs);
+
+  try {
+    return await task();
+  } finally {
+    clearInterval(keepAliveTimer);
+    await inFlightHeartbeat;
+  }
+}


### PR DESCRIPTION
Добавлен ограниченный keepalive для длительного обновления staging-списков в background: он включается только на время скачивания и проверки больших remote static lists, а затем гарантированно выключается. Это не влияет на корректность логики возобновления, а лишь снижает вероятность повторной загрузки крупных списков вроде accounts.jsonl после остановки background. Также добавлены тесты и подробные комментарии для ревьюеров о том, почему механизм узко ограничен и не используется как постоянное удержание background.