### PR TITLE
Reset frontend alias statuses on periodic re-check

### DIFF
--- a/src/entrypoints/background/@services/frontend-service.ts
+++ b/src/entrypoints/background/@services/frontend-service.ts
@@ -48,6 +48,9 @@ export class FrontendService {
 
     this.availabilityCheckTimestamp = Date.now();
 
+    // Without reset, a fallback alias marked "available" after a brief primary hiccup stays selected until SW restart
+    this.aliasManagerForFrontend.resetStatuses();
+
     let aliasToUse: AliasToUse | undefined;
     while ((aliasToUse = this.aliasManagerForFrontend.findAliasToUse())) {
       const fetchResult = await fetchFromAlias({


### PR DESCRIPTION
Без сброса статусов при периодической проверке (раз в час) запасной алиас, помеченный как «доступный» после кратковременного сбоя основного, оставался выбранным до перезапуска service worker. Теперь при каждой проверке статусы сбрасываются, и обнаружение начинается заново — основной алиас проверяется первым и возвращается в работу, как только становится доступен.