### PR TITLE
Gracefully stop polling when background service worker is gone

### DIFF
--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -4,6 +4,7 @@ import { getContentLogger } from "@/shared/@logging/categories";
 import { setupGlobalCatchAllLogging } from "@/shared/@logging/global-catch-all";
 import { setupLogging } from "@/shared/@logging/setup";
 import { type ContentId, contentIdSchema } from "@/shared/@primitives/misc";
+import { setBackgroundAvailabilityCheck } from "@/shared/background-availability";
 import { loggingService } from "@/shared/proxy-services";
 import { browser, defineContentScript, getAppConfig } from "#imports";
 
@@ -62,6 +63,7 @@ export default defineContentScript({
 
     const { contentId, contentLogger } = setupContentId();
     setupGlobalCatchAllLogging({ logger: contentLogger });
+    setBackgroundAvailabilityCheck(() => !ctx.isInvalid);
 
     contentLogger.debug(
       "Loading content script with content id {contentId} for {url}",

--- a/src/entrypoints/content/dx-overlays.ts
+++ b/src/entrypoints/content/dx-overlays.ts
@@ -1,5 +1,9 @@
 import type { DxConfig } from "@/shared/@model/dx-config";
 import type { PollVersion } from "@/shared/@pollable/core";
+import {
+  backgroundAbortSignal,
+  isBackgroundGone,
+} from "@/shared/background-availability";
 import { dxConfigService } from "@/shared/proxy-services";
 
 function updateOverlayDataAttributes(config: DxConfig): void {
@@ -24,9 +28,25 @@ function updateOverlayDataAttributes(config: DxConfig): void {
 
 export async function startManagingDxOverlays(): Promise<void> {
   let lastVersion: PollVersion | undefined = undefined;
-  for (;;) {
-    const result = await dxConfigService.poll(lastVersion);
-    lastVersion = result.version;
-    updateOverlayDataAttributes(result.value);
+  try {
+    for (;;) {
+      if (isBackgroundGone()) {
+        break;
+      }
+      const result = await dxConfigService.poll(lastVersion);
+      lastVersion = result.version;
+      updateOverlayDataAttributes(result.value);
+    }
+  } catch (error: unknown) {
+    if (!isBackgroundGone(error)) {
+      // eslint-disable-next-line no-restricted-syntax -- service calls are only expected to throw when background is gone; re-throwing unknown defects
+      throw error;
+    }
   }
+
+  backgroundAbortSignal.addEventListener("abort", () => {
+    delete document.documentElement.dataset["bnInsertionFraming"];
+    delete document.documentElement.dataset["bnInsertionLabeling"];
+    delete document.documentElement.dataset["bnInsertionsHidden"];
+  });
 }

--- a/src/entrypoints/content/insertion-management.ts
+++ b/src/entrypoints/content/insertion-management.ts
@@ -3,6 +3,7 @@ import { isEqual } from "es-toolkit";
 
 import type { InsertionConfig } from "@/shared/@model/insertion-configs";
 import type { ContentId } from "@/shared/@primitives/misc";
+import { backgroundAbortSignal } from "@/shared/background-availability";
 import { dxConfigService, staticListsService } from "@/shared/proxy-services";
 
 import type { DerivedPageInfo } from "./derived-page-info";
@@ -130,9 +131,13 @@ export async function startManagingInsertions({
     },
   });
 
-  window.addEventListener("beforeunload", () => {
+  function teardown() {
     mutationObserver.disconnect();
     stopPolling();
     unmountAllInsertions(instanceMap);
-  });
+    style.remove();
+  }
+
+  backgroundAbortSignal.addEventListener("abort", teardown);
+  window.addEventListener("beforeunload", teardown);
 }

--- a/src/entrypoints/content/insertion-management/global-rerender.ts
+++ b/src/entrypoints/content/insertion-management/global-rerender.ts
@@ -5,6 +5,7 @@ import type { InsertionConfig } from "@/shared/@model/insertion-configs";
 import type { StaticListItem } from "@/shared/@model/static-lists";
 import type { PollVersion } from "@/shared/@pollable/core";
 import type { ContentId } from "@/shared/@primitives/misc";
+import { isBackgroundGone } from "@/shared/background-availability";
 import {
   dxConfigService,
   extensionVersionService,
@@ -181,23 +182,34 @@ export function startGlobalRerenderPolling({
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic use of any entry
   async function watch(thingToPoll: ThingToPoll<any>) {
-    const initial = await thingToPoll.poll(undefined);
-    let lastPollVersion = initial.version;
+    try {
+      const initial = await thingToPoll.poll(undefined);
+      let lastPollVersion = initial.version;
 
-    for (;;) {
-      const result = await thingToPoll.poll(lastPollVersion);
+      for (;;) {
+        if (isBackgroundGone()) {
+          break;
+        }
 
-      if (disposed) {
-        break;
+        const result = await thingToPoll.poll(lastPollVersion);
+
+        if (disposed || isBackgroundGone()) {
+          break;
+        }
+
+        if (result.version !== lastPollVersion) {
+          logger.debug(`${thingToPoll.id} changed, refreshing insertions`);
+          thingToPoll.onVersionChange?.(result.value);
+          triggerRefreshAndMount();
+        }
+
+        lastPollVersion = result.version;
       }
-
-      if (result.version !== lastPollVersion) {
-        logger.debug(`${thingToPoll.id} changed, refreshing insertions`);
-        thingToPoll.onVersionChange?.(result.value);
-        triggerRefreshAndMount();
+    } catch (error: unknown) {
+      if (!isBackgroundGone(error) && !disposed) {
+        // eslint-disable-next-line no-restricted-syntax -- service calls are only expected to throw when background is gone; re-throwing unknown defects
+        throw error;
       }
-
-      lastPollVersion = result.version;
     }
   }
 

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -8,6 +8,7 @@ import { setupGlobalCatchAllLogging } from "@/shared/@logging/global-catch-all";
 import { EntrypointLoggerProvider } from "@/shared/@logging/react";
 import { setupLogging } from "@/shared/@logging/setup";
 import { TooltipProvider } from "@/shared/@ui-primitives/tooltip";
+import { setBackgroundAvailabilityCheck } from "@/shared/background-availability";
 import { loggingService } from "@/shared/proxy-services";
 
 import { ActiveTab } from "./app/active-tab";
@@ -20,6 +21,8 @@ const logger = getPopupLogger();
 function startPopupApp() {
   setupLogging(loggingService);
   setupGlobalCatchAllLogging({ logger });
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- browser.runtime.id becomes nullish when extension context is invalidated
+  setBackgroundAvailabilityCheck(() => Boolean(browser.runtime?.id));
 
   window.addEventListener(
     "pagehide",

--- a/src/entrypoints/sidepanel/app.tsx
+++ b/src/entrypoints/sidepanel/app.tsx
@@ -9,6 +9,7 @@ import { EntrypointLoggerProvider } from "@/shared/@logging/react";
 import { setupLogging } from "@/shared/@logging/setup";
 import { LogoLink } from "@/shared/@ui-primitives/logo";
 import { TooltipProvider } from "@/shared/@ui-primitives/tooltip";
+import { setBackgroundAvailabilityCheck } from "@/shared/background-availability";
 import { loggingService } from "@/shared/proxy-services";
 
 import { SidepanelMain } from "./app/main";
@@ -18,6 +19,8 @@ const logger = getSidepanelLogger();
 function startSidepanelApp() {
   setupLogging(loggingService);
   setupGlobalCatchAllLogging({ logger });
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- browser.runtime.id becomes nullish when extension context is invalidated
+  setBackgroundAvailabilityCheck(() => Boolean(browser.runtime?.id));
 
   window.addEventListener(
     "pagehide",

--- a/src/shared/@logging/global-catch-all.ts
+++ b/src/shared/@logging/global-catch-all.ts
@@ -19,6 +19,8 @@ const ignoredGlobalRuntimeErrorPatterns = [
   // Browser-generated noise from page-level ResizeObserver churn can spam logs
   // without indicating an extension defect, so we suppress it centrally here.
   /^ResizeObserver loop completed with undelivered notifications\.$/u,
+  /Extension context invalidated/u,
+  /message channel closed before a response was received/u,
 ] as const;
 
 type WrappedConsoleMethod = (typeof wrappedConsoleMethods)[number];
@@ -180,13 +182,14 @@ function forwardConsoleCall({
   });
 }
 
+/** @returns `true` if the event was suppressed (caller should `preventDefault`) */
 function forwardErrorEvent({
   event,
   runtimeLogger,
 }: {
   event: Event;
   runtimeLogger: Logger;
-}): void {
+}): boolean {
   const error = getEventValue(event, "error");
   const colno = getEventValue(event, "colno");
   const filename = getEventValue(event, "filename");
@@ -194,7 +197,7 @@ function forwardErrorEvent({
   const message = getErrorMessage(event);
 
   if (shouldIgnoreGlobalRuntimeMessage(message)) {
-    return;
+    return true;
   }
 
   logWithLevel({
@@ -211,20 +214,23 @@ function forwardErrorEvent({
       message,
     },
   });
+
+  return false;
 }
 
+/** @returns `true` if the event was suppressed (caller should `preventDefault`) */
 function forwardUnhandledRejection({
   event,
   runtimeLogger,
 }: {
   event: Event;
   runtimeLogger: Logger;
-}): void {
+}): boolean {
   const reason = getEventValue(event, "reason");
   const message = getUnhandledRejectionMessage(event);
 
   if (shouldIgnoreGlobalRuntimeMessage(message)) {
-    return;
+    return true;
   }
 
   logWithLevel({
@@ -236,6 +242,8 @@ function forwardUnhandledRejection({
       ...(reason === undefined ? {} : { reason }),
     },
   });
+
+  return false;
 }
 
 /**
@@ -280,6 +288,9 @@ export function setupGlobalCatchAllLogging({
     return;
   }
 
+  // preventDefault() on suppressed events stops the browser from printing
+  // "Uncaught" / "Uncaught (in promise)" lines to the console for errors
+  // we intentionally ignore (e.g. "Extension context invalidated").
   globalThis.addEventListener("error", (event) => {
     if (state.isForwarding) {
       return;
@@ -287,7 +298,9 @@ export function setupGlobalCatchAllLogging({
 
     state.isForwarding = true;
     try {
-      forwardErrorEvent({ event, runtimeLogger });
+      if (forwardErrorEvent({ event, runtimeLogger })) {
+        event.preventDefault();
+      }
     } finally {
       state.isForwarding = false;
     }
@@ -300,7 +313,9 @@ export function setupGlobalCatchAllLogging({
 
     state.isForwarding = true;
     try {
-      forwardUnhandledRejection({ event, runtimeLogger });
+      if (forwardUnhandledRejection({ event, runtimeLogger })) {
+        event.preventDefault();
+      }
     } finally {
       state.isForwarding = false;
     }

--- a/src/shared/@pollable/react.ts
+++ b/src/shared/@pollable/react.ts
@@ -5,6 +5,7 @@ import * as React from "react";
 import type { JsonValue } from "type-fest";
 
 import { useEntrypointLogger } from "../@logging/react";
+import { isBackgroundGone } from "../background-availability";
 import type { PollResult, PollVersion } from "./core";
 
 type UsePollableValue<
@@ -106,53 +107,64 @@ export function createPollableValueHook<
     latestRecord = { ...latestRecord, watcherId };
     payloadKeyRecordMap.set(payloadKey, latestRecord);
 
-    for (;;) {
-      if (throttleInterval && throttleInterval > 0) {
-        await delay(throttleInterval);
-      }
+    try {
+      for (;;) {
+        if (isBackgroundGone()) {
+          break;
+        }
 
-      const { version: lastPollVersion } = await latestRecord.pollResult;
-      const newPollResult = await poll(lastPollVersion, latestRecord.payload);
+        if (throttleInterval && throttleInterval > 0) {
+          await delay(throttleInterval);
+        }
 
-      latestRecord = payloadKeyRecordMap.get(payloadKey);
-      if (latestRecord?.watcherId !== watcherId) {
-        break;
-      }
+        const { version: lastPollVersion } = await latestRecord.pollResult;
+        const newPollResult = await poll(lastPollVersion, latestRecord.payload);
 
-      latestRecord = { ...latestRecord, pollResult: newPollResult };
-      payloadKeyRecordMap.set(payloadKey, latestRecord);
+        latestRecord = payloadKeyRecordMap.get(payloadKey);
+        if (latestRecord?.watcherId !== watcherId) {
+          break;
+        }
 
-      for (const setter of latestRecord.setters) {
-        setter((oldValue) =>
-          isEqual(oldValue, newPollResult.value)
-            ? oldValue
-            : newPollResult.value,
-        );
-      }
+        latestRecord = { ...latestRecord, pollResult: newPollResult };
+        payloadKeyRecordMap.set(payloadKey, latestRecord);
 
-      const newValueDebugLogPayload = formatNewValueDebugLog
-        ? formatNewValueDebugLog({
+        for (const setter of latestRecord.setters) {
+          setter((oldValue) =>
+            isEqual(oldValue, newPollResult.value)
+              ? oldValue
+              : newPollResult.value,
+          );
+        }
+
+        const newValueDebugLogPayload = formatNewValueDebugLog
+          ? formatNewValueDebugLog({
+              lastPollVersion,
+              newPollResult,
+              setterCount: latestRecord.setters.length,
+              watcherId,
+            })
+          : {
+              message:
+                "Received new value {newValue} (version {lastPollVersion} -> {newPollVersion}), notified {setterCount} component(s) in watcher {watcherId}",
+              properties: {
+                newValue: newPollResult.value,
+              },
+            };
+
+        if (newValueDebugLogPayload !== undefined) {
+          logger.debug(newValueDebugLogPayload.message, {
             lastPollVersion,
-            newPollResult,
+            newPollVersion: newPollResult.version,
             setterCount: latestRecord.setters.length,
             watcherId,
-          })
-        : {
-            message:
-              "Received new value {newValue} (version {lastPollVersion} -> {newPollVersion}), notified {setterCount} component(s) in watcher {watcherId}",
-            properties: {
-              newValue: newPollResult.value,
-            },
-          };
-
-      if (newValueDebugLogPayload !== undefined) {
-        logger.debug(newValueDebugLogPayload.message, {
-          lastPollVersion,
-          newPollVersion: newPollResult.version,
-          setterCount: latestRecord.setters.length,
-          watcherId,
-          ...newValueDebugLogPayload.properties,
-        });
+            ...newValueDebugLogPayload.properties,
+          });
+        }
+      }
+    } catch (error: unknown) {
+      if (!isBackgroundGone(error)) {
+        // eslint-disable-next-line no-restricted-syntax -- service calls are only expected to throw when background is gone; re-throwing unknown defects
+        throw error;
       }
     }
 

--- a/src/shared/@ui-helpers/data-hooks.ts
+++ b/src/shared/@ui-helpers/data-hooks.ts
@@ -10,6 +10,7 @@ import type {
 } from "../@model/static-lists";
 import { createPollableValueHook } from "../@pollable/react";
 import type { VkDomain } from "../@primitives/vk";
+import { isBackgroundGone } from "../background-availability";
 import {
   authService,
   dxConfigService,
@@ -161,6 +162,10 @@ export function useStaticListsAutoUpdate(payload?: {
     void staticListsService.updateIfNeeded(stablePayload);
 
     const interval = setInterval(() => {
+      if (isBackgroundGone()) {
+        clearInterval(interval);
+        return;
+      }
       void staticListsService.updateIfNeeded(stablePayload);
     }, 60 * 1000);
 

--- a/src/shared/background-availability.ts
+++ b/src/shared/background-availability.ts
@@ -1,0 +1,47 @@
+import { getLogger } from "@logtape/logtape";
+
+import { baseLoggerCategory } from "./@logging/categories";
+
+let check: (() => boolean) | undefined;
+let warnedAboutMissingCheck = false;
+
+const logger = getLogger([baseLoggerCategory, "background-availability"]);
+const controller = new AbortController();
+
+export const backgroundAbortSignal: AbortSignal = controller.signal;
+
+export function setBackgroundAvailabilityCheck(fn: () => boolean): void {
+  check = fn;
+}
+
+const backgroundGoneErrorPatterns = [
+  /Extension context invalidated/u,
+  /message channel closed/u,
+];
+
+export function isBackgroundGone(error?: unknown): boolean {
+  if (controller.signal.aborted) {
+    return true;
+  }
+  if (error !== undefined) {
+    const message = error instanceof Error ? error.message : "";
+    if (backgroundGoneErrorPatterns.some((p) => p.test(message))) {
+      controller.abort();
+      return true;
+    }
+  }
+  if (!check) {
+    if (!warnedAboutMissingCheck) {
+      warnedAboutMissingCheck = true;
+      logger.warn(
+        "isBackgroundGone() called before setBackgroundAvailabilityCheck()",
+      );
+    }
+    return false;
+  }
+  if (!check()) {
+    controller.abort();
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Когда фоновый скрипт расширения останавливается (расширение отключено или обновлено), контент-скрипты, попап и боковая панель продолжали опрашивать прокси-сервисы, вызывая спам ошибок "Extension context invalidated" и "message channel closed" в консоли.

## Обнаружение недоступности фона

Добавлен общий модуль `background-availability.ts` с единой функцией `isBackgroundGone(error?)`:

- без аргумента — проверяет, доступен ли фон (через зарегистрированную проверку или AbortSignal)
- с аргументом — дополнительно проверяет, указывает ли ошибка на недоступность фона (по паттерну сообщения), и помечает фон недоступным, если да

Каждая точка входа регистрирует свою проверку при инициализации через `setBackgroundAvailabilityCheck()`:

- контент-скрипт: `!ctx.isInvalid` (встроенная проверка WXT)
- попап и боковая панель: `Boolean(browser.runtime?.id)`

Экспортируется `backgroundAbortSignal` (AbortSignal) для подписки на событие недоступности фона.

## Остановка опроса

Все циклы опроса (`@pollable/react.ts`, `global-rerender.ts`, `dx-overlays.ts`) проверяют `isBackgroundGone()` перед каждой итерацией и тихо завершаются при недоступности фона. Единственный try/catch на цикл ловит ошибки от запросов, которые были в полёте в момент отключения — `isBackgroundGone(error)` определяет, нужно ли проглотить ошибку или пробросить дальше. `useStaticListsAutoUpdate` очищает свой интервал при обнаружении недоступности фона.

## Очистка UI

При недоступности фона:

- все вставки (insertions) размонтируются, стили удаляются
- data-атрибуты DX-оверлеев (`bnInsertionFraming`, `bnInsertionLabeling`, `bnInsertionsHidden`) удаляются с `document.documentElement`

## Подавление ошибок

Паттерны "Extension context invalidated" и "message channel closed" добавлены в `ignoredGlobalRuntimeErrorPatterns` как страховочная сетка для edge-case ошибок, которые могут проскочить мимо polling-гардов.
