### PR TITLE
Update Renovate limits

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,8 @@
   ],
   "lockFileMaintenance": { "enabled": true },
   "postUpdateOptions": ["pnpmDedupe"],
-  "prConcurrentLimit": 1,
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 1,
   "rangeStrategy": "pin",
   "timezone": "Etc/UTC",
   "packageRules": [


### PR DESCRIPTION
Увеличено число параллельных ПР от Renovate. Создаётся максимум 1 ПР в час.