### PR TITLE
Use vk.ru as the canonical VK domain

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -71,7 +71,7 @@ jobs:
           {
             echo "notes<<NOTES_EOF"
             printf '%s\n' "<!--"
-            printf '%s\n' "Анонс:  [Сайт](https://botnadzor.org/news/??) • [TG](https://t.me/botnadzor_org/??) • [VK](https://vk.com/wall-187686148_??)"
+            printf '%s\n' "Анонс:  [Сайт](https://botnadzor.org/news/??) • [TG](https://t.me/botnadzor_org/??) • [VK](https://vk.ru/wall-187686148_??)"
             printf '%s\n' "-->"
             [[ -n "$DIFF_LINE" ]] && printf '%s\n' "$DIFF_LINE"
             printf '%s\n' "[Инструкция по установке](${INSTALL_URL})"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Botnadzor extension development guide
 
-Browser extension for vk.com (bot/spam detection).
+Browser extension for vk.ru (bot/spam detection).
 Built with WXT, React, TypeScript, TailwindCSS.
 
 ## Key architecture

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Расширение Ботнадзор<br><em>Botnadzor extension</em>
 
-_Botnadzor browser extension highlights bots on [vk.com](https://vk.com) and VK-related sites.  
+_Botnadzor browser extension highlights bots on [vk.ru](https://vk.ru) and VK-related sites.  
 Learn more at [botnadzor.org/extension](https://botnadzor.org/extension) (ru)._
 
 _For the English version of this README, [see it on Google Translate](https://translate.google.com/translate?sl=ru&tl=en&u=https://github.com/botnadzor/extension/blob/main/README.md)._
@@ -12,14 +12,14 @@ _For the English version of this README, [see it on Google Translate](https://tr
 [![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE.md)
 [![CI](https://img.shields.io/github/actions/workflow/status/botnadzor/extension/ci.yaml?branch=main&label=CI)](https://github.com/botnadzor/extension/actions/workflows/ci.yaml)
 
-Браузерное расширение Ботнадзор подсвечивает ботов на [vk.com](https://vk.com) и связанных сайтах.  
+Браузерное расширение Ботнадзор подсвечивает ботов на [vk.ru](https://vk.ru) и связанных сайтах.  
 Подробнее о расширении: [botnadzor.org/extension](https://botnadzor.org/extension).
 
 ## Что делает расширение
 
 <img src="docs/assets/botnadzor-extension-insertions.png" alt="Подсветка ботов в VK и вставка карточек" width="600">
 
-- Подсвечивает ботов на сайтах VK: ([m.](https://m.vk.com))[vk.com](https://vk.com), ([m.](https://m.vk.ru))[vk.ru](https://vk.ru), ([m.](https://m.vkvideo.ru))[vkvideo.ru](https://vkvideo.ru), а также на веб-архиве: [web.archive.org](https://web.archive.org)
+- Подсвечивает ботов на сайтах VK: ([m.](https://m.vk.ru))[vk.ru](https://vk.ru), ([m.](https://m.vkvideo.ru))[vkvideo.ru](https://vkvideo.ru), а также на прежнем домене ([m.](https://m.vk.com))[vk.com](https://vk.com) и в веб-архиве [web.archive.org](https://web.archive.org), включая снимки старых доменов `vkontakte.ru` и `m.vkontakte.ru`
 - Упрощает вставку [карточек ботов](https://botnadzor.org/docs/how-to-help#cards) в ответ на их комментарии
 - Позволяет узнавать дату регистрации аккаунтов VK
 - Позволяет изучать подозрительную активность аккаунтов с помощью встроенного инспектора
@@ -40,11 +40,11 @@ _для Windows, Android, macOS и Linux_
     _Надпись на кнопке может быть немного другой, она зависит от браузера_
 
 1.  Откройте VK-паблик, где часто бывают боты  
-    _например, [ria](https://vk.com/ria), [rt_russian](https://vk.com/rt_russian), [vesti](https://vk.com/vesti), [mash](https://vk.com/mash)_
+    _например, [ria](https://vk.ru/ria), [rt_russian](https://vk.ru/rt_russian), [vesti](https://vk.ru/vesti), [mash](https://vk.ru/mash)_
 
     Теперь вы видите ботов в комментариях и&nbsp;профилях&nbsp;VK!
 
-    Пожалуйста, [поддержите наш проект](https://botnadzor.org/docs/how-to-help) донатом, а&nbsp;также оставляйте [карточки ботов в&nbsp;VK](https://botnadzor.org/docs/how-to-help#cards) и&nbsp;подпишитесь на&nbsp;наши&nbsp;соцсети: [Telegram](https://t.me/botnadzor_org),&nbsp;[VK](https://vk.com/botnadzor).
+    Пожалуйста, [поддержите наш проект](https://botnadzor.org/docs/how-to-help) донатом, а&nbsp;также оставляйте [карточки ботов в&nbsp;VK](https://botnadzor.org/docs/how-to-help#cards) и&nbsp;подпишитесь на&nbsp;наши&nbsp;соцсети: [Telegram](https://t.me/botnadzor_org),&nbsp;[VK](https://vk.ru/botnadzor).
 
 ### Firefox
 
@@ -55,11 +55,11 @@ _В том числе **TOR Browser**_
 1.  Нажмите кнопку _«Добавить в Firefox»_
 
 1.  Откройте VK-паблик, где часто бывают боты  
-    _например, [ria](https://vk.com/ria), [rt_russian](https://vk.com/rt_russian), [vesti](https://vk.com/vesti), [mash](https://vk.com/mash)_
+    _например, [ria](https://vk.ru/ria), [rt_russian](https://vk.ru/rt_russian), [vesti](https://vk.ru/vesti), [mash](https://vk.ru/mash)_
 
     Теперь вы видите ботов в комментариях и&nbsp;профилях&nbsp;VK!
 
-    Пожалуйста, [поддержите наш проект](https://botnadzor.org/docs/how-to-help) донатом, а&nbsp;также оставляйте [карточки ботов в&nbsp;VK](https://botnadzor.org/docs/how-to-help#cards) и&nbsp;подпишитесь на&nbsp;наши&nbsp;соцсети: [Telegram](https://t.me/botnadzor_org),&nbsp;[VK](https://vk.com/botnadzor).
+    Пожалуйста, [поддержите наш проект](https://botnadzor.org/docs/how-to-help) донатом, а&nbsp;также оставляйте [карточки ботов в&nbsp;VK](https://botnadzor.org/docs/how-to-help#cards) и&nbsp;подпишитесь на&nbsp;наши&nbsp;соцсети: [Telegram](https://t.me/botnadzor_org),&nbsp;[VK](https://vk.ru/botnadzor).
 
 ## Установка из GitHub Releases
 

--- a/src/curated-static-lists/insertions.ts
+++ b/src/curated-static-lists/insertions.ts
@@ -13,7 +13,7 @@ export default [
   /**
    * Follower (user card tile) on desktop (React-based UI: tabs have outlines and shadows)
    * Examples:
-   * - https://vk.com/ria → followers (needs login)
+   * - https://vk.ru/ria → followers (needs login)
    */
   {
     id: "desktopDialogFollower",
@@ -107,7 +107,7 @@ export default [
    * Followers (user card tiles) on desktop (pre-React UI: tabs have border-bottom)
    *
    * Examples:
-   * - https://vk.com/durov → click "followers"
+   * - https://vk.ru/durov → click "followers"
    */
   {
     id: "desktopPreReactDialogFollower",
@@ -207,7 +207,7 @@ export default [
   /**
    * Followers (list of user cards) on desktop (React-based UI: tabs have outlines and shadows)
    * Examples:
-   * - https://vk.com/ria → followers (needs login)
+   * - https://vk.ru/ria → followers (needs login)
    */
   {
     id: "desktopDialogFollowers",
@@ -267,15 +267,15 @@ export default [
   /*
    * Desktop reactions dialog (Pre-React UI: list of user cards instead of a list)
    * Examples:
-   * - post (logged out): https://vk.com/ria?w=likes%2Fwall-15755094_48295538
-   * - comment (logged out): https://vk.com/wall-173277106_4892265?w=likes%2Fwall_reply-173277106_4892462
-   * - followers (logged in): https://vk.com/durov → click "followers"
+   * - post (logged out): https://vk.ru/ria?w=likes%2Fwall-15755094_48295538
+   * - comment (logged out): https://vk.ru/wall-173277106_4892265?w=likes%2Fwall_reply-173277106_4892462
+   * - followers (logged in): https://vk.ru/durov → click "followers"
    */
   {
     id: "desktopPreReactDialogReactions",
     variant: "accountList",
     appliesTo: "desktopVkWebsite",
-    // Excluding .ui_search to not match Subscriptions dialog - e.g. https://vk.com/id558910327 → click "subscriptions"
+    // Excluding .ui_search to not match Subscriptions dialog - e.g. https://vk.ru/id558910327 → click "subscriptions"
     selector:
       "#box_layer_wrap:has(.fans_rows):not(:has(.ui_search)),#wk_layer_wrap:has(.fans_rows)",
     markup: {
@@ -330,8 +330,8 @@ export default [
   /*
    * Desktop reactions dialog
    * Examples:
-   * - post (logged in): https://vk.com/wall-173277106_4892265?reply=4892462&w=likes%2Fwall-173277106_4892265
-   * - comment (logged in): https://vk.com/wall-173277106_4892265?reply=4892462&w=reactions-173277106_4892462%3Ftype%3Dcomment
+   * - post (logged in): https://vk.ru/wall-173277106_4892265?reply=4892462&w=likes%2Fwall-173277106_4892265
+   * - comment (logged in): https://vk.ru/wall-173277106_4892265?reply=4892462&w=reactions-173277106_4892462%3Ftype%3Dcomment
    */
   {
     id: "desktopDialogReactions",
@@ -388,8 +388,8 @@ export default [
   /**
    * Desktop reaction (user card tile) in Pre-React UI reactions dialog
    * Examples:
-   * - https://vk.com/ria?w=likes%2Fwall-15755094_48295538
-   * - https://vk.com/ria?w=likes%2Fwall_reply-15755094_49579807
+   * - https://vk.ru/ria?w=likes%2Fwall-15755094_48295538
+   * - https://vk.ru/ria?w=likes%2Fwall_reply-15755094_49579807
    */
   {
     id: "desktopPreReactDialogReaction",
@@ -481,9 +481,9 @@ export default [
   /**
    * Desktop profile page header
    * Examples:
-   * - https://vk.com/id1
-   * - https://vk.com/durov
-   * - https://m.vk.com/id1034309676
+   * - https://vk.ru/id1
+   * - https://vk.ru/durov
+   * - https://m.vk.ru/id1034309676
    */
   {
     id: "desktopProfileHeader",
@@ -553,9 +553,9 @@ export default [
   /**
    * Mobile profile page header
    * Examples:
-   * - https://m.vk.com/id1
-   * - https://m.vk.com/durov
-   * - https://m.vk.com/id1034309676
+   * - https://m.vk.ru/id1
+   * - https://m.vk.ru/durov
+   * - https://m.vk.ru/id1034309676
    */
   {
     id: "mobileProfileHeader",
@@ -621,8 +621,8 @@ export default [
   /**
    * Legacy desktop post header (wall page posts)
    * Examples:
-   * - Posts on user/community walls (vk.com/wall-*)
-   * - https://vk.com/wall1034309676_77
+   * - Posts on user/community walls (vk.ru/wall-*)
+   * - https://vk.ru/wall1034309676_77
    */
 
   // or without login regular post
@@ -685,10 +685,10 @@ export default [
   /**
    * Modern desktop feed posts ([data-testid="post"])
    * Examples:
-   * - Posts in VK feed (vk.com/feed)
+   * - Posts in VK feed (vk.ru/feed)
    * - Posts on user/community walls with modern layout
-   * - https://vk.com/wall1034309676_77
-   * - https://m.vk.com/wall1034309676_77
+   * - https://vk.ru/wall1034309676_77
+   * - https://m.vk.ru/wall1034309676_77
    */
   {
     id: "desktopAndMobilePost",
@@ -763,8 +763,8 @@ export default [
   /**
    * Mobile page posts ([data-testid="post"])
    * Examples:
-   * - Posts on m.vk.com user/community walls
-   * - https://m.vk.com/wall1034309676_77 (without login)
+   * - Posts on m.vk.ru user/community walls
+   * - https://m.vk.ru/wall1034309676_77 (without login)
    */
   {
     id: "mobilePreReactPost",
@@ -837,7 +837,7 @@ export default [
    * Desktop repost headers
    * Examples:
    * - Repost content on walls/feeds
-   * - https://vk.com/wall1034309676_77 (without login)
+   * - https://vk.ru/wall1034309676_77 (without login)
    */
   {
     id: "desktopPreReactRepost",
@@ -885,7 +885,7 @@ export default [
   /**
    * Desktop search results (people / communities)
    * Examples:
-   * - https://vk.com/search?c%5Bsection%5D=people
+   * - https://vk.ru/search?c%5Bsection%5D=people
    */
   {
     id: "desktopAndMobilePeopleList",
@@ -952,8 +952,8 @@ export default [
 
   /*
    * Examples:
-   * - https://m.vk.com/wall-140899168_3954792?reply=3955042 -- TODO: Fix  link or annotate it with instructions (relationship to this insertion is unclear)
-   * - https://vk.com/wall-173277106_4892265?reply=4892462&w=reactions-173277106_4892462%3Ftype%3Dcomment
+   * - https://m.vk.ru/wall-140899168_3954792?reply=3955042 -- TODO: Fix  link or annotate it with instructions (relationship to this insertion is unclear)
+   * - https://vk.ru/wall-173277106_4892265?reply=4892462&w=reactions-173277106_4892462%3Ftype%3Dcomment
    */
   {
     id: "desktopAndMobileLikeCell",
@@ -1032,7 +1032,7 @@ export default [
     },
   },
 
-  // - https://m.vk.com/incident22?act=members
+  // - https://m.vk.ru/incident22?act=members
   {
     id: "mobileSubCell",
     variant: "account",
@@ -1090,7 +1090,7 @@ export default [
    * Desktop community post author (expanded text)
    * Examples:
    * - Author links in expanded community post text
-   * - https://vk.com/wall-60212615_5184695
+   * - https://vk.ru/wall-60212615_5184695
    */
 
   {
@@ -1221,7 +1221,7 @@ export default [
     },
   },
 
-  // - https://m.vk.com/video-85596321_456270337?reply=182214
+  // - https://m.vk.ru/video-85596321_456270337?reply=182214
   {
     id: "mobileWindowComment",
     variant: "comment",
@@ -1278,7 +1278,7 @@ export default [
   /**
    * Modern desktop comments
    * Examples:
-   * - New VK wall post comments (vk.com/ria)
+   * - New VK wall post comments (vk.ru/ria)
    */
   {
     id: "desktopComment",
@@ -1358,7 +1358,7 @@ export default [
   /**
    * Legacy desktop wall groups comments (.reply._post)
    * Examples:
-   * - Wall posts with groups comments without login (vk.com/ria)
+   * - Wall posts with groups comments without login (vk.ru/ria)
    */
 
   // TODO: photo comment too - need to build comment id
@@ -1459,8 +1459,8 @@ export default [
   /**
    * Desktop video comments
    * Examples:
-   * - Comments on video pages (vk.com/video*)
-   * - https://vk.com/video-85596321_456270337?reply=182214
+   * - Comments on video pages (vk.ru/video*)
+   * - https://vk.ru/video-85596321_456270337?reply=182214
    */
   {
     id: "desktopVideoComment",
@@ -1530,7 +1530,7 @@ export default [
   /**
    * Legacy mobile comments (without login)
    * Examples:
-   * - https://m.vk.com/wall-20169232_9024015
+   * - https://m.vk.ru/wall-20169232_9024015
    */
   {
     id: "mobileComment",
@@ -1599,8 +1599,8 @@ export default [
   /**
    * Modern mobile feed comments (with login)
    * Examples:
-   * - New mobile VK feed wall post comments (m.vk.com)
-   * - https://m.vk.com/wall-20169232_9024015
+   * - New mobile VK feed wall post comments (m.vk.ru)
+   * - https://m.vk.ru/wall-20169232_9024015
    */
   {
     id: "mobileCommentNew",
@@ -1736,7 +1736,7 @@ export default [
   /**
    * Reply form in pre-React UI, e.g. in popovers with photos
    * Examples:
-   * - https://vk.com/ria?z=photo-15755094_459774936
+   * - https://vk.ru/ria?z=photo-15755094_459774936
    */
   {
     id: "desktopPreReactReplyForm",
@@ -1776,7 +1776,7 @@ export default [
 
   /**
    * Examples:
-   * - https://vk.com/reviews-187080127
+   * - https://vk.ru/reviews-187080127
    */
   {
     id: "desktopReview",
@@ -1835,7 +1835,7 @@ export default [
 
   /**
    * Examples:
-   * - https://m.vk.com/reviews-187080127
+   * - https://m.vk.ru/reviews-187080127
    */
   {
     id: "mobileReview",

--- a/src/entrypoints/background/@service-helpers/dynamic-api-endpoints/=inspect-account.ts
+++ b/src/entrypoints/background/@service-helpers/dynamic-api-endpoints/=inspect-account.ts
@@ -39,7 +39,7 @@ const legacyCommentSchema = z.readonly(
     count: z.exactOptional(z.nullable(z.number())), // e.g 547
     name: z.string(), // e.g "АСТ-54"
     color: z.exactOptional(z.nullable(z.string())), // e.g "rgba(253, 167, 223, 0.6)"
-    link: z.url(), // e.g "https://vk.com/club31101527"
+    link: z.url(), // e.g "https://vk.ru/club31101527"
     photo: legacyNullableUrlSchema, // e.g. "https://sun9-23.userapi.com/s/v1/ig2/A2eBnT_ucMlAPFnfMWL72CpaRMJgeo8LINkbyDeGB7sL4nIgtcfwYgybnjPa_Vb1pXdgVfmL3Dea__ofaRp6Tv3U.jpg?quality=95&crop=36,76,320,320&as=32x32,48x48,72x72,108x108,160x160,240x240&ava=1&cs=200x200"
     mark: z.exactOptional(z.nullable(z.xor([z.string(), z.number()]))),
     reg_name: z.exactOptional(z.nullable(z.string())), // e.g "Алтайский край"
@@ -48,7 +48,7 @@ const legacyCommentSchema = z.readonly(
 
 const legacyLikeLinkSchema = z.readonly(
   z.object({
-    url: z.string(), // e.g "https://vk.com/wall-20351570_215747?reply=215779&thread=215762",
+    url: z.string(), // e.g "https://vk.ru/wall-20351570_215747?reply=215779&thread=215762",
     title: z.string(), // e.g "Иван Иванов",
     src: legacyNullableUrlSchema, // аватарка группы, где лайкнули коммент
     data: z.string(), // e.g "1. group_slug"

--- a/src/entrypoints/background/@service-helpers/vk-domain-resolver.ts
+++ b/src/entrypoints/background/@service-helpers/vk-domain-resolver.ts
@@ -61,7 +61,7 @@ export class VkDomainResolver {
 
     let pageText: string | undefined;
     let timeoutId: NodeJS.Timeout | undefined;
-    const urlToFetch = `https://vk.com/${vkNickname}`;
+    const urlToFetch = `https://vk.ru/${vkNickname}`;
 
     try {
       const controller = new AbortController();

--- a/src/entrypoints/background/@services/collecting-service.ts
+++ b/src/entrypoints/background/@services/collecting-service.ts
@@ -53,8 +53,8 @@ type CommentToCollect = {
   commentVkId: PositiveVkId;
 
   /**
-   * @example vk.com/id123 -> commenterVkDomain = "id123"
-   * @example vk.com/someone -> commenterVkDomain = "someone"
+   * @example vk.ru/id123 -> commenterVkDomain = "id123"
+   * @example vk.ru/someone -> commenterVkDomain = "someone"
    */
   commenterVkDomain: VkDomain;
 

--- a/src/entrypoints/content/derived-page-info.test.ts
+++ b/src/entrypoints/content/derived-page-info.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { derivePageInfo } from "./derived-page-info";
+
+function locationFromUrl(url: string): Pick<Location, "host" | "pathname"> {
+  return new URL(url);
+}
+
+describe("derivePageInfo", () => {
+  it.each([
+    "https://vk.ru/id1",
+    "https://vk.com/id1",
+    "https://vkvideo.ru/video-1_1",
+  ])("supports desktop host %s", (url) => {
+    expect(derivePageInfo(locationFromUrl(url))).toEqual({
+      archivedSnapshot: false,
+      websiteVariant: "desktopVkWebsite",
+    });
+  });
+
+  it.each(["https://m.vk.ru/id1", "https://m.vk.com/id1"])(
+    "supports mobile host %s",
+    (url) => {
+      expect(derivePageInfo(locationFromUrl(url))).toEqual({
+        archivedSnapshot: false,
+        websiteVariant: "mobileVkWebsite",
+      });
+    },
+  );
+
+  it.each([
+    [
+      "https://web.archive.org/web/20110101000000/http://vkontakte.ru/id1",
+      "desktopVkWebsite",
+    ],
+    [
+      "https://web.archive.org/web/20110101000000id_/http://m.vkontakte.ru/id1",
+      "mobileVkWebsite",
+    ],
+    [
+      "https://web.archive.org/web/20260101000000/https://vk.com/id1",
+      "desktopVkWebsite",
+    ],
+  ] as const)("supports archived host %s", (url, websiteVariant) => {
+    expect(derivePageInfo(locationFromUrl(url))).toEqual({
+      archivedSnapshot: true,
+      websiteVariant,
+    });
+  });
+
+  it("does not support a historical alias directly", () => {
+    expect(
+      derivePageInfo(locationFromUrl("https://vkontakte.ru/id1")),
+    ).toBeUndefined();
+  });
+});

--- a/src/entrypoints/content/derived-page-info.ts
+++ b/src/entrypoints/content/derived-page-info.ts
@@ -1,11 +1,14 @@
 import {
-  type ContentScriptHost,
+  type ArchivedContentScriptHost,
+  archivedContentScriptHosts,
   contentScriptHosts,
 } from "./hosts-and-matches";
 
 export type WebsiteVariant = "mobileVkWebsite" | "desktopVkWebsite";
 
-function getMatchedHost(location: Location): ContentScriptHost | undefined {
+function getMatchedHost(
+  location: Pick<Location, "host" | "pathname">,
+): ArchivedContentScriptHost | undefined {
   const directMatch = contentScriptHosts.find((host) => location.host === host);
 
   if (directMatch) {
@@ -16,11 +19,12 @@ function getMatchedHost(location: Location): ContentScriptHost | undefined {
     return undefined;
   }
 
-  for (const host of contentScriptHosts) {
+  for (const host of archivedContentScriptHosts) {
+    const escapedHost = host.replaceAll(".", String.raw`\.`);
     if (
-      new RegExp(String.raw`^/web/\d+/https?://${host}/`).test(
-        location.pathname,
-      )
+      new RegExp(
+        String.raw`^/web/\d+(?:[a-z]{2}_)?/https?://${escapedHost}/`,
+      ).test(location.pathname)
     ) {
       return host;
     }
@@ -35,7 +39,7 @@ export type DerivedPageInfo = {
 };
 
 export function derivePageInfo(
-  location: Location,
+  location: Pick<Location, "host" | "pathname">,
 ): DerivedPageInfo | undefined {
   const matchedHost = getMatchedHost(location);
 

--- a/src/entrypoints/content/hosts-and-matches.test.ts
+++ b/src/entrypoints/content/hosts-and-matches.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  archivedContentScriptHosts,
+  contentScriptHosts,
+  contentScriptMatches,
+} from "./hosts-and-matches";
+
+describe("content script hosts and matches", () => {
+  it("prioritizes canonical hosts while retaining live aliases", () => {
+    expect(contentScriptHosts).toEqual([
+      "vk.ru",
+      "vkvideo.ru",
+      "m.vk.ru",
+      "m.vkvideo.ru",
+      "vk.com",
+      "m.vk.com",
+    ]);
+  });
+
+  it("retains historical aliases only for archived snapshots", () => {
+    expect(archivedContentScriptHosts).toContain("vkontakte.ru");
+    expect(archivedContentScriptHosts).toContain("m.vkontakte.ru");
+
+    expect(contentScriptMatches).toContain(
+      "*://web.archive.org/*/vkontakte.ru/*",
+    );
+    expect(contentScriptMatches).toContain(
+      "*://web.archive.org/*/m.vkontakte.ru/*",
+    );
+    expect(contentScriptMatches).not.toContain("https://vkontakte.ru/*");
+  });
+});

--- a/src/entrypoints/content/hosts-and-matches.ts
+++ b/src/entrypoints/content/hosts-and-matches.ts
@@ -1,18 +1,28 @@
 export const contentScriptHosts = [
-  "vk.com",
   "vk.ru",
   "vkvideo.ru",
-
-  "m.vk.com",
   "m.vk.ru",
   "m.vkvideo.ru",
+
+  // Legacy aliases remain supported while they are still reachable.
+  "vk.com",
+  "m.vk.com",
 ] as const;
 
-export type ContentScriptHost = (typeof contentScriptHosts)[number];
+export const archivedContentScriptHosts = [
+  ...contentScriptHosts,
+  "vkontakte.ru",
+  "m.vkontakte.ru",
+] as const;
+
+export type ArchivedContentScriptHost =
+  (typeof archivedContentScriptHosts)[number];
 
 export const contentScriptMatches = [
   ...contentScriptHosts.map((host) => `https://${host}/*`),
-  ...contentScriptHosts.map((host) => `*://web.archive.org/*/${host}/*`),
+  ...archivedContentScriptHosts.map(
+    (host) => `*://web.archive.org/*/${host}/*`,
+  ),
 ];
 
 /**

--- a/src/entrypoints/content/in-page-app/inspector/account-activity.tsx
+++ b/src/entrypoints/content/in-page-app/inspector/account-activity.tsx
@@ -210,7 +210,7 @@ function LikeRow({ like }: { like: LikeToBot }) {
             )}
           >
             <a
-              href={`https://vk.com/id${like.bot_id}`}
+              href={`https://vk.ru/id${like.bot_id}`}
               target="_blank"
               rel="noopener noreferrer"
               className="u-link whitespace-nowrap"

--- a/src/entrypoints/content/in-page-app/toasts/toast-with-welcome-message.tsx
+++ b/src/entrypoints/content/in-page-app/toasts/toast-with-welcome-message.tsx
@@ -35,7 +35,7 @@ export function ToastWithWelcomeMessage() {
             label: "Сайт проекта",
           },
           {
-            href: "https://vk.com/botnadzor",
+            href: "https://vk.ru/botnadzor",
             Icon: VkIcon,
             label: "Группа VK: botnadzor",
           },

--- a/src/entrypoints/content/insertion-styling.css
+++ b/src/entrypoints/content/insertion-styling.css
@@ -181,7 +181,7 @@
   }
 }
 
-/* space_gray is used on m.vk.com for dark theme */
+/* space_gray is used on m.vk.ru for dark theme */
 @custom-variant dark ([scheme="vkcom_dark"] &,
                       [scheme="space_gray"] &
                     );

--- a/src/entrypoints/content/insertion-variants/=account-list/active-tab.ts
+++ b/src/entrypoints/content/insertion-variants/=account-list/active-tab.ts
@@ -40,11 +40,11 @@ function normalizeSourceToken(value: string): string | undefined {
   }
 
   const withoutQuery = sanitizedValue.replaceAll(/[?#].*$/g, "");
-  if (!URL.canParse(withoutQuery, "https://vk.com")) {
+  if (!URL.canParse(withoutQuery, "https://vk.ru")) {
     return withoutQuery;
   }
 
-  const normalizedUrl = new URL(withoutQuery, "https://vk.com");
+  const normalizedUrl = new URL(withoutQuery, "https://vk.ru");
   return normalizedUrl.pathname || withoutQuery;
 }
 

--- a/src/entrypoints/content/insertion-variants/=comment.ts
+++ b/src/entrypoints/content/insertion-variants/=comment.ts
@@ -55,7 +55,7 @@ export type CommentInnerData = {
 /**
  * Supports values like:
  * - /wall-123_456?reply=789
- * - https://vk.com/photo-123_456?reply=789
+ * - https://vk.ru/photo-123_456?reply=789
  * - https://m.vk.ru/video123_456?reply=789
  * - ... replyClick('wall-123_456', 798 ...
  * - ... replyClick('123_456', 798 ...
@@ -71,7 +71,7 @@ async function extractCommentIdentifierFromMarkup(
     commentIdentifierSelector,
     instanceLogger,
     (value) => {
-      // Try URL format: /wall-123_456?reply=789 or https://vk.com/photo-123_456?reply=789
+      // Try URL format: /wall-123_456?reply=789 or https://vk.ru/photo-123_456?reply=789
       const urlRegexp =
         /(?:https?:\/\/[^/]+)?\/(photo|video|wall)(-?\d+)_(\d+)/;
       const urlMatch = urlRegexp.exec(value);

--- a/src/entrypoints/content/insertion-variants/shared/@markup-data/account-avatar.ts
+++ b/src/entrypoints/content/insertion-variants/shared/@markup-data/account-avatar.ts
@@ -8,6 +8,6 @@ export function extractAccountAvatarUrlFromMarkup(
 ): string {
   return (
     resolveImageUrlSelector(rootElement, accountAvatarSelector) ??
-    "https://vk.com/images/camera_200.png"
+    "https://vk.ru/images/camera_200.png"
   );
 }

--- a/src/entrypoints/content/insertion-variants/shared/@markup-data/account-identifier.test.ts
+++ b/src/entrypoints/content/insertion-variants/shared/@markup-data/account-identifier.test.ts
@@ -65,12 +65,12 @@ describe("parseAccountIdentifier", () => {
     ["/public123", communityId(123)],
     ["/video/@id123", accountId(123)],
     ["/video/id123", accountId(123)],
-    ["https://vk.com/id123", accountId(123)],
-    ["https://vk.com/id123?hello=world", accountId(123)],
-    ["https://vk.com/id123#fragment", accountId(123)],
-    ["https://vk.com/public123", communityId(123)],
-    ["https://vk.com/video/@id123", accountId(123)],
-    ["https://vk.com/video/id123", accountId(123)],
+    ["https://vk.ru/id123", accountId(123)],
+    ["https://vk.ru/id123?hello=world", accountId(123)],
+    ["https://vk.ru/id123#fragment", accountId(123)],
+    ["https://vk.ru/public123", communityId(123)],
+    ["https://vk.ru/video/@id123", accountId(123)],
+    ["https://vk.ru/video/id123", accountId(123)],
     ["/testing", nickname("testing")],
 
     // Plain id

--- a/src/shared/url-helpers.test.ts
+++ b/src/shared/url-helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultVkBaseUrl, detectVkBaseUrl } from "./url-helpers";
+
+describe("VK URL helpers", () => {
+  it("uses vk.ru as the canonical base URL", () => {
+    expect(defaultVkBaseUrl).toBe("https://vk.ru");
+  });
+
+  it.each([
+    ["https://vk.ru/id1", "https://vk.ru"],
+    ["https://m.vk.ru/id1", "https://m.vk.ru"],
+    ["https://vk.com/id1", "https://vk.com"],
+    ["https://m.vk.com/id1", "https://m.vk.com"],
+  ])("preserves the active live alias for %s", (url, expected) => {
+    expect(detectVkBaseUrl(url)).toBe(expected);
+  });
+
+  it.each([
+    "https://web.archive.org/web/20110101000000/http://vkontakte.ru",
+    "https://web.archive.org/web/20110101000000/http://m.vkontakte.ru",
+    "https://web.archive.org/web/20260101000000/https://vk.com",
+    "https://web.archive.org/web/20260101000000id_/https://m.vk.ru",
+  ])("preserves the archived base URL for %s", (url) => {
+    expect(detectVkBaseUrl(`${url}/id1`)).toBe(url);
+  });
+
+  it("falls back to the canonical URL for unrelated hosts", () => {
+    expect(detectVkBaseUrl("https://example.com/vk.ru/id1")).toBe(
+      "https://vk.ru",
+    );
+  });
+});

--- a/src/shared/url-helpers.ts
+++ b/src/shared/url-helpers.ts
@@ -57,17 +57,18 @@ export function generateUrl(
   return `${baseUrl}${generateHref(pathname, searchParams ?? {}, hash)}`;
 }
 
-export const defaultVkBaseUrl = "https://vk.com";
+export const defaultVkBaseUrl = "https://vk.ru";
 
 export function detectVkBaseUrl(url: string): string {
-  const [officialMatch] = /^https:\/\/(?:m\.)?vk\.(com|ru)/.exec(url) ?? [];
+  const [officialMatch] =
+    /^https:\/\/(?:m\.)?vk\.(?:ru|com)(?=\/|$)/.exec(url) ?? [];
 
   if (officialMatch) {
     return officialMatch;
   }
 
   const [webArchiveMatch] =
-    /^https:\/\/web\.archive\.org\/web\/\d+\/https?:\/\/((?:m\.)?vk\.(com|ru)|vkontakte\.ru)/.exec(
+    /^https:\/\/web\.archive\.org\/web\/\d+(?:[a-z]{2}_)?\/https?:\/\/(?:(?:m\.)?vk\.(?:ru|com)|(?:m\.)?vkontakte\.ru)(?=\/|$)/.exec(
       url,
     ) ?? [];
 

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -149,7 +149,7 @@ export default defineConfig({
   }),
 
   webExt: {
-    startUrls: ["https://vk.com/ria"],
+    startUrls: ["https://vk.ru/ria"],
   },
 
   zip: {


### PR DESCRIPTION
Переведены генерируемые, служебные и документированные ссылки VK на канонический домен vk.ru. Домены vk.com и m.vk.com сохранены как совместимые алиасы для работы расширения.

Для web.archive.org добавлена поддержка исторических доменов vkontakte.ru и m.vkontakte.ru, а также URL с модификаторами режима воспроизведения Wayback Machine. Архивные ссылки продолжают использовать исходный домен снимка.

Добавлены регрессионные тесты для списка хостов, определения варианта страницы и выбора базового URL.